### PR TITLE
US7277 - Update markup for user authentication

### DIFF
--- a/src/app/components/register/register.component.html
+++ b/src/app/components/register/register.component.html
@@ -48,7 +48,7 @@
               [(ngModel)]="email">
 
         <div class="errors" *ngIf="(submitted) && (!regForm.controls['email'].valid || duplicateUser)">
-          <p class="error help-block" *ngIf="duplicateUser">This email address is already in use. <a (click)="back()">Sign In</a> or try <a [href]="forgotPasswordUrl" target="_blank">Forgot password</a>.</p>
+          <p class="error help-block" *ngIf="duplicateUser">This email address is already in use. <a routerLink="/signin">Sign In</a> or try <a [href]="forgotPasswordUrl" target="_blank">Forgot password</a>.</p>
 
           <p class="error help-block" *ngIf="!duplicateUser">Email <span [innerHTML]="switchMessage(regForm.controls['email'].errors)"></span></p>
         </div>


### PR DESCRIPTION
Fixing broken link on the email field. If registering an account with an email already in use, the validation message should contain a link to sign-in.

Corresponds with the development branch of crds-styles.