### PR TITLE
DE3028 - Search icon missing in Safari/iOS

### DIFF
--- a/src/app/components/search-bar/search-bar.component.html
+++ b/src/app/components/search-bar/search-bar.component.html
@@ -10,7 +10,7 @@
           <span class="input-group-btn">
             <button type="submit" class="btn btn-secondary" (click)="onSearch(searchText)">
               <svg class="icon icon-1" viewBox="0 0 256 256">
-                <use href="/assets/svgs/icons.svg#search"></use>
+                <use xlink:href="/assets/svgs/icons.svg#search"></use>
               </svg>
             </button>
           </span>


### PR DESCRIPTION
I fixed the attribute linking to the search SVG. 

Corresponds with crds-styles/development and crdschurch/crds-styleguide#87

----------
the magnifying glass icon in the search submit button does not show in safari on ios and mac 