### PR TITLE
clear cookie expiration date on expire so we can still store things i…

### DIFF
--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -39,8 +39,8 @@ export class SessionService {
   }
 
   private extractAuthTokenAndUnwrapBody = (res: Response) => {
-    if (res.headers != null && res.headers.get('sesssionId')) {
-      this.setAccessToken(res.headers.get('sessionId'));
+    if (res.headers != null && res.headers.get('sessionid')) {
+      this.setAccessToken(res.headers.get('sessionid'));
     }
 
     if (res.headers != null && res.headers.get('refreshToken')) {
@@ -89,6 +89,7 @@ export class SessionService {
   }
 
   public clearTokens(): void {
+    this.cookieOptions.expires = null;
     this.cookieService.remove(this.accessToken, this.cookieOptions);
     this.cookieService.remove(this.refreshToken, this.cookieOptions);
   }


### PR DESCRIPTION
…n the cookie. apparently, sessionid stores the auth token from the headers but sessionId does not.