### PR TITLE
DE3051 - Center cluster labels on icons

### DIFF
--- a/src/app/directives/google-map-cluster.directive.ts
+++ b/src/app/directives/google-map-cluster.directive.ts
@@ -34,17 +34,14 @@ export class GoogleMapClusterDirective implements AfterContentInit {
 
   ngAfterContentInit() {
     this.wrapper.getNativeMap().then(map => {
-      let clusterStyle = [{
-        url: 'http://i.imgur.com/Ut4iAtI.png',
-        height: 50,
-        width: 50,
-        textColor: '#fff'
-      }];
       let options = {
         averageCenter: true,
-        imagePath: 'http://i.imgur.com/Ut4iAtI.png',
-        imageExtension: 'png',
-        styles: clusterStyle
+        styles: [{
+          url: '//crds-cms-uploads.s3.amazonaws.com/connect/CLUSTER.svg',
+          height: 50,
+          width: 50,
+          textColor: '#fff'
+        }]
       };
       let sebmMarkers = <IMarkerManager>this.markerManager["_markers"].keys(); //markerKeys();
       let markers = [];

--- a/src/app/directives/google-map-cluster.directive.ts
+++ b/src/app/directives/google-map-cluster.directive.ts
@@ -28,8 +28,8 @@ export class GoogleMapClusterDirective implements AfterContentInit {
     this.wrapper.getNativeMap().then(map => {
       let clusterStyle = [{
         url: '/assets/CLUSTER.svg',
-        height: 53,
-        width: 53,
+        height: 50,
+        width: 50,
         textColor: '#fff'
       }];
       let options = {


### PR DESCRIPTION
Changing the size of the cluster marker centers the icon text.

Corresponds with the development branches of crds-styles/development

----------
the number inside the cluster icon is not centered in the icon