### PR TITLE
US7511 Remove ‘duplicate’ pins

### DIFF
--- a/src/app/components/neighbors/neighbors.component.ts
+++ b/src/app/components/neighbors/neighbors.component.ts
@@ -66,9 +66,47 @@ export class NeighborsComponent implements OnInit {
     this.api.getPinsAddressSearchResults(searchString, lat, lng).subscribe(
       next => {
         this.pinSearchResults = next as PinSearchResultsDto;
+
+        // sort
         this.pinSearchResults.pinSearchResults =
           this.pinSearchResults.pinSearchResults.sort(
-            (p1: Pin, p2: Pin) => { return p1.proximity - p2.proximity; });
+            (p1: Pin, p2: Pin) => {
+              if (p1.proximity !== p2.proximity) {
+                return p1.proximity - p2.proximity; // asc
+              } else if (p1.firstName && p2.firstName && (p1.firstName !== p2.firstName)) {
+                return p1.firstName.localeCompare(p2.firstName); // asc
+              } else if (p1.lastName && p2.lastName && (p1.lastName !== p2.lastName)) {
+                return p1.lastName.localeCompare(p2.lastName); // asc
+              } else {
+                return p2.pinType - p1.pinType; // des
+              }
+            }
+          );
+
+        // uniq - algorithm takes advantage of being sorted
+        let lastIndex = null;
+        this.pinSearchResults.pinSearchResults =
+          this.pinSearchResults.pinSearchResults.filter(
+            (p, index, self) => {
+              if (p.pinType === 3) {
+                lastIndex = -1;
+                return true;
+              } else if (lastIndex === -1) {
+                lastIndex = index;
+                return true;
+              } else {
+                let pl = self[lastIndex];
+                let test = (p.proximity !== pl.proximity) ||
+                           (p.firstName !== pl.firstName) ||
+                           (p.lastName  !== pl.lastName );
+                if (test) {
+                  lastIndex = index;
+                }
+                return test;
+              }
+            }
+          );
+
         this.state.setLoading(false);
 
         if (this.mapViewActive) {


### PR DESCRIPTION
Sort the pins by proximity (asc) and then firstName (asc), lastName (asc), and pinType (des), then uniq them by proximity, firstName and lastName. This gets rid of person pin types with the same proximity and name as host pins.