### PR TITLE
Defect/de3112 map screen scrollbar

### DIFF
--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -247,12 +247,16 @@ app-search-bar {
 }
 
 // Style map
+app-map {
+  display: block;
+  height: calc(100vh - 110px);
+  overflow: hidden;
+  position: relative;
+  width: 100vw;
+}
+
 sebm-google-map {
-  position: absolute;
-  height: calc(100% - 110px);
-  width: 100%;
-  top: 110px; // Height of the app header and search bar
-  background-color: $cr-gray-lighter;
+  height: calc(100vh - 110px);
 
   @media (min-width: $screen-xs) {
     .gmnoprint {
@@ -261,13 +265,9 @@ sebm-google-map {
   }
 }
 
-.sebm-google-map-container-inner {
-  height: 100% !important;
-}
-
 canvas-map-overlay {
   display: block;
-  height: calc(100vh - 69px);
+  height: calc(100vh - 110px);
   pointer-events: none;
   position: absolute;
   width: 100vw;
@@ -389,12 +389,12 @@ list-footer {
 search-local {
   display: block;
   position: absolute;
-  top: 115px;
+  top: 5px;
   left: 50px;
   z-index: 4;
 
   @media (min-width: $screen-xs) {
-    top: 123px;
+    top: 13px;
     left: 60px;
   }
 }

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -246,18 +246,34 @@ app-search-bar {
   }
 }
 
+app-map,
+sebm-google-map,
+canvas-map-overlay {
+  height: calc(100vh - 112px); // Height of map minus header height
+}
+
 // Style map
 app-map {
   display: block;
-  height: calc(100vh - 110px);
   overflow: hidden;
   position: relative;
   width: 100vw;
 }
 
-sebm-google-map {
-  height: calc(100vh - 110px);
+/* fix iOS bug not displaying height correctly */
+  /* iphone6+ */
+  @media only screen
+    and (max-device-width: 640px),
+    only screen and (max-device-width: 667px),
+    only screen and (max-width: 480px) {
+    app-map,
+    sebm-google-map,
+    canvas-map-overlay {
+      height: calc(100vh - 180px);
+    }
+  }
 
+sebm-google-map {
   @media (min-width: $screen-xs) {
     .gmnoprint {
       padding: .5rem;
@@ -267,7 +283,6 @@ sebm-google-map {
 
 canvas-map-overlay {
   display: block;
-  height: calc(100vh - 110px);
   pointer-events: none;
   position: absolute;
   width: 100vw;


### PR DESCRIPTION
Fixed the map layout so the map view isn't scrollable. 
Corresponds with crds-styles/development

---------
The newly added global header changed the layout for the map screen. Map screen should not be scrollable.