### PR TITLE
DE3113 - Align the buttons and searchbar

### DIFF
--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -167,10 +167,11 @@ app-add-me-to-map {
 
 // Centers blocks to the middle of the screen.
 .content-middle {
-  @extend .center-block;
-  width: 100%;
-  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: $container-tablet;
   text-align: center;
+  width: 100%;
 }
 
 // Map searchbar
@@ -182,7 +183,7 @@ app-search-bar {
   padding: .5rem 1rem;
   background-color: darken(desaturate($cr-blue-dark, 5), 5);
 
-  header {
+  > div {
     display: flex;
     justify-content: flex-start;
 
@@ -194,10 +195,6 @@ app-search-bar {
 
     > button {
       margin-left: 6px;
-
-      @media (min-width: $screen-xs) {
-        margin-left: 24px;
-      }
     }
   }
 


### PR DESCRIPTION
Refactor the centering class used on the searchbar area. The flexbox properties got overwritten in a merge, which is why the horizontal alignment was off.

Corresponds with crds-styles/development

-------------
Search Bar and list/Map Toggle are misaligned vertically