### PR TITLE
US7699 - Refactor Map Size

### DIFF
--- a/src/app/components/map-content/map-content.component.ts
+++ b/src/app/components/map-content/map-content.component.ts
@@ -49,6 +49,7 @@ export class MapContentComponent implements OnInit {
           streetViewControlOptions: streetViewControlOptions,
           minZoom: 3,
           maxZoom: 20,
+          scrollwheel: false,
           styles: [
             {
               "elementType": "geometry",
@@ -227,12 +228,12 @@ export class MapContentComponent implements OnInit {
 
         map.addListener("zoom_changed", () => {
           self.clearCanvas();
-          
+
           let center = map.getCenter();
           let zoom = map.getZoom();
           let mapViewUpdate = new MapView("zoom_changed", center.lat(), center.lng(), zoom);
           self.mapHlpr.emitMapViewUpdated(mapViewUpdate);
-          self.state.setMapView(mapViewUpdate);          
+          self.state.setMapView(mapViewUpdate);
         });
       });
   }

--- a/src/app/components/map-footer/map-footer.component.html
+++ b/src/app/components/map-footer/map-footer.component.html
@@ -1,12 +1,8 @@
-<footer class="container">
-  <div class="btn-group pull-right">
-    <input type="button"
-          class="btn btn-primary"
-          value="Getting Started"
-          (click)="gettingStartedBtnClicked()">
-    <input type="button"
-          class="btn btn-primary"
-          value="My Pin"
-          (click)="myPinBtnClicked()">
-  </div>
-</footer>
+<input type="button"
+      class="btn btn-sm btn-primary"
+      value="Getting Started"
+      (click)="gettingStartedBtnClicked()">
+<input type="button"
+      class="btn btn-sm btn-primary"
+      value="My Pin"
+      (click)="myPinBtnClicked()">

--- a/src/app/components/neighbors/neighbors.component.ts
+++ b/src/app/components/neighbors/neighbors.component.ts
@@ -39,7 +39,6 @@ export class NeighborsComponent implements OnInit {
   }
 
   public ngOnInit(): void {
-    debugger;
     let haveResults = !!this.pinSearchResults;
     if (!haveResults) {
       this.state.setLoading(true);

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -248,7 +248,10 @@ sebm-google-map,
 canvas-map-overlay {
   // Calculations are designed such that while the screen is less than 3000px
   // tall, the map is never too short, but also never more than 99px below
-  // the bottom of the screen.
+  // the bottom of the screen directly within Connect.
+  // 
+  // When displayed as a microclient, it may fall another 54px-64px below
+  // the footer, accounting for the global header.
   height: 381px;
   @for $idx from 5 to 30 {
     $height: $idx * 100;

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -288,9 +288,14 @@ canvas-map-overlay {
 // Map footer
 app-map-footer {
   position: absolute;
+  width: 0;
+  height: 0;
   top: 5px;
   right: 1rem;
   z-index: 4;
+  @media (min-width: $screen-xs) {
+    top: 13px;
+  }
   input {
     float: right;
     clear: both;
@@ -430,7 +435,6 @@ search-local {
   z-index: 4;
 
   @media (min-width: $screen-xs) {
-    top: 13px;
-    left: 60px;
+    top: 93px;
   }
 }

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -246,7 +246,16 @@ app-search-bar {
 app-map,
 sebm-google-map,
 canvas-map-overlay {
-  height: 600px;
+  // Calculations are designed such that while the screen is less than 3000px
+  // tall, the map is never too short, but also never more than 99px below
+  // the bottom of the screen.
+  height: 381px;
+  @for $idx from 5 to 30 {
+    $height: $idx * 100;
+    @media screen and ( min-height: #{$height}px ){
+      height: #{$height - 19}px;
+    }
+  }
 }
 
 // Style map

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -275,10 +275,14 @@ canvas-map-overlay {
 
 // Map footer
 app-map-footer {
-  bottom: 0;
   position: absolute;
-  width: 100%;
+  top: 5px;
+  right: 1rem;
   z-index: 4;
+  input {
+    float: right;
+    clear: both;
+  }
 }
 
 .screen-getting-started {
@@ -409,8 +413,8 @@ list-footer {
 search-local {
   display: block;
   position: absolute;
-  top: 5px;
-  left: 50px;
+  top: 85px;
+  right: 1rem;
   z-index: 4;
 
   @media (min-width: $screen-xs) {

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -246,7 +246,7 @@ app-search-bar {
 app-map,
 sebm-google-map,
 canvas-map-overlay {
-  height: calc(100vh - 112px); // Height of map minus header height
+  height: 600px;
 }
 
 // Style map
@@ -256,19 +256,6 @@ app-map {
   position: relative;
   width: 100vw;
 }
-
-/* fix iOS bug not displaying height correctly */
-  /* iphone6+ */
-  @media only screen
-    and (max-device-width: 640px),
-    only screen and (max-device-width: 667px),
-    only screen and (max-width: 480px) {
-    app-map,
-    sebm-google-map,
-    canvas-map-overlay {
-      height: calc(100vh - 180px);
-    }
-  }
 
 sebm-google-map {
   @media (min-width: $screen-xs) {


### PR DESCRIPTION
From @zarahzachz:

> what taylor, brian and becky netted on for this was that:
>
> 1. we need to disable the scroll-zoom so the user can scroll on the page successfully (done)
> 2. change the height of the map to a fixed px-based height and it's ok if the content scrolls past the bottom of the screen (for mobile) or there's white space (desktop) (kinda done?)
> 3. footer buttons should be reconfigured to be positioned at the top of the map so they aren't cut off on small screens
> 
> i'd suggest adding some media queries on the height so it's not so jarring on different devices
> 
> and taylor recommended repositioning all of the map buttons (redo search, my pin and getting started) to sit vertically atop each other on the top-right side of the screen