### PR TITLE
DE3228 - Add cancel button

### DIFF
--- a/src/app/components/address-form/address-form.component.html
+++ b/src/app/components/address-form/address-form.component.html
@@ -85,8 +85,9 @@
     </div>
   </div>
 
-  <footer class="page-footer">
+  <footer class="page-footer page-footer-vertical">
     <button type="submit" [disabled]="addressFormGroup.invalid" class="btn btn-secondary">{{buttonText}}</button>
+    <button type="button" routerLink="/getting-started" class="btn btn-link btn-default">Cancel</button>
   </footer>
 
   <div *ngIf="submissionError" class="alert alert-danger">

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -59,6 +59,10 @@ app-add-me-to-map {
     display: flex;
     justify-content: center;
     align-items: center;
+
+    &.page-footer-vertical {
+      flex-direction: column;
+    }
   }
 
   &.fauxdal-center {


### PR DESCRIPTION
Add btn link style for a cancel button to add-me-to-map. Should redirect to the previous page (/getting-started) and be positioned vertical/center.

Access by going to Get started -> Add me to map.

Corresponds with crds-styles/development

----------
When I navigate to the Add me to the map page there is no cancel button, but there should be.