### PR TITLE
DE3229 - Fauxdal 'X'

### DIFF
--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -49,13 +49,18 @@ app-add-me-to-map {
   z-index: 7;
 
   .close {
+    opacity: 1.0;
+
     position: absolute;
     top: 1rem;
     right: 1rem;
-    opacity: 1.0;
 
     a {
       color: $cr-white;
+
+      display: block;
+      padding: 1rem;
+      margin: -1rem;
 
       &:hover {
         color: rgba($cr-white, .5);


### PR DESCRIPTION
Increase clickable area around 'X' on fauxdals.

![close-hover](https://cloud.githubusercontent.com/assets/5159392/24879787/f89109ba-1e05-11e7-87d2-ca3097c8c479.gif)

Peter pointed that on Edge 14, the right side of the icon didn't have a hover state (but it was the only browser with this problem). Increasing the clickable area fixes this problem and helps people with fat hands navigate.
