### PR TITLE
DE3307 - Disable fullscreen map btn

### DIFF
--- a/src/app/components/map-content/map-content.component.ts
+++ b/src/app/components/map-content/map-content.component.ts
@@ -73,7 +73,8 @@ export class MapContentComponent implements OnInit {
           minZoom: 3,
           maxZoom: 20,
           scrollwheel: false,
-          styles: googleMapStyles
+          styles: googleMapStyles,
+          fullscreenControl: false
         });
 
           let self = this;


### PR DESCRIPTION
Remove the fullscreen map button functionality - this feature is not supported across all mobile devices. 

in an Android browser, there is a Full Screen map toggle underneath the Get Started Button on /connect