### PR TITLE
DE3264 - Active buttons

### DIFF
--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -724,3 +724,11 @@ search-local {
     }
   }
 }
+
+
+
+
+// 🚨 Temp fix - Need higher contrast for active states on btns (to be revisited).
+.btn.btn-primary.active {
+  background: darken($btn-primary-bg, 20);
+}


### PR DESCRIPTION
Temporary fix to increase the contrast of active/non-active buttons.

"My stuff" button should have more obvious active state. Test by adding/removing `active` to this button.

Corresponds with crds-styles/development

----------
The active state should be a more obvious different color than the inactive state.