### PR TITLE
DE3299 - Input shadow on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "angulartics2": "1.5.2",
     "copyfiles": "1.0.0",
     "core-js": "2.4.1",
-    "crds-styles": "0.4.0",
+    "crds-styles": "crdschurch/crds-styles#development",
     "iframe-resizer": "3.5.9",
     "intl": "1.2.5",
     "moment": "2.17.0",

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -724,3 +724,13 @@ search-local {
     }
   }
 }
+
+
+
+
+// Searchbar text shadow fix for iOS
+.input-group {
+  .form-control {
+    -webkit-appearance: none;
+  }
+}


### PR DESCRIPTION
Add local style to fix shadow on searchbar input field. Only visible in iOS.

*This style already exists in `crds-styles/development` but because we've locked the versions, `crds-connect` can't access this updated style. This style is added as a fix until it can access the latest from `crds-styles/development`*