### PR TITLE
DE3328 - Fix my stuff button

### DIFF
--- a/src/app/components/map-footer/map-footer.component.ts
+++ b/src/app/components/map-footer/map-footer.component.ts
@@ -43,11 +43,11 @@ export class MapFooterComponent {
     this.state.setLoading(true);
     this.state.setCurrentView('map');
     this.state.setMyViewOrWorldView('my');
+    this.state.myStuffActive = true;
 
     if (!this.session.isLoggedIn()) {
       this.loginRedirectService.redirectToLogin('/');
     } else {
-      this.state.myStuffActive = true;
       this.userLocationService.GetUserLocation().subscribe(
           pos => {
               this.myPinSearchResults = new PinSearchResultsDto(new GeoCoordinates(pos.lat, pos.lng), new Array<Pin>());


### PR DESCRIPTION
Add the class of active to the My stuff button once the button is clicked, regardless if the user is logged in or not.

Corresponds with crds-styles/development

----------
While not being logged in, Click "My Stuff" > Sign In as a user with Stuff on the Map => Goes back to the map and the My Stuff button is not in the active state. 

This Should be in an active state at this point.

It seems to be working as expected in other scenarios.