### PR TITLE
US7962 - Roll back the map overlay fix for iOS

### DIFF
--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -300,11 +300,6 @@ canvas-map-overlay {
   z-index: 1;
 }
 
-// Fix map error overlay
-.gm-style .gm-style-pbc {
-  z-index: 1050 !important;
-}
-
 // Map footer
 app-map-footer {
   position: absolute;


### PR DESCRIPTION
In my hubris, I thought I could fix something even The Mighty Google Maps could not fix.

Removing the increased z-index fix on the map overlay.

Corresponds with crds-styles/development