### PR TITLE
US7375 - Clean Up Confirmation Screens

### DIFF
--- a/src/app/components/pin-details/gathering/gathering-requests/gathering-requests.component.spec.ts
+++ b/src/app/components/pin-details/gathering/gathering-requests/gathering-requests.component.spec.ts
@@ -88,7 +88,7 @@ describe('GatheringRequestsComponent', () => {
         let expectedBPD = new BlandPageDetails(
             'Return to my pin',
             // tslint:disable-next-line:max-line-length
-            '<div class="container"><div class="row text-center"><h3>Request accepted</h3></div><br/><div class="row text-center"<span>Joe K. has been notified</span></div></div>',
+            '<h1 class="title text-lowercase">Request accepted</h1><p>Joe K. has been notified.</p>',
             BlandPageType.Text,
             BlandPageCause.Success,
             'gathering/' + comp.pin.gathering.groupId
@@ -109,7 +109,7 @@ describe('GatheringRequestsComponent', () => {
         let expectedBPD = new BlandPageDetails(
             'Return to my pin',
             // tslint:disable-next-line:max-line-length
-            '<div class="container"><div class="row text-center"><h3>Request Denied</h3></div><br/><div class="row text-center"<span>Joe K. has been notified</span></div></div>',
+            '<h1 class="title text-lowercase">Request Denied</h1><p>Joe K. has been notified.</p>',
             BlandPageType.Text,
             BlandPageCause.Success,
             'gathering/' + comp.pin.gathering.groupId

--- a/src/app/components/pin-details/gathering/gathering-requests/gathering-requests.component.ts
+++ b/src/app/components/pin-details/gathering/gathering-requests/gathering-requests.component.ts
@@ -57,12 +57,12 @@ export class GatheringRequestsComponent implements OnInit {
         let templateText;
         let bpd;
         if (approve) {
-          templateText = '<div class="container"><div class="row text-center"><h3>Request accepted</h3></div>';
+          templateText = '<h1 class="title text-lowercase">Request accepted</h1>';
         } else {
-          templateText = '<div class="container"><div class="row text-center"><h3>Request Denied</h3></div>';
+          templateText = '<h1 class="title text-lowercase">Request Denied</h1>';
         }
         // tslint:disable-next-line:max-line-length
-        templateText += `<br/><div class="row text-center"<span>${inquiry.firstName} ${inquiry.lastName.slice(0, 1)}. has been notified</span></div></div>`;
+        templateText += `<p>${inquiry.firstName} ${inquiry.lastName.slice(0, 1)}. has been notified.</p>`;
         bpd = new BlandPageDetails(
           'Return to my pin',
           templateText,

--- a/src/app/components/pin-details/gathering/invite-someone/invite-someone.component.spec.ts
+++ b/src/app/components/pin-details/gathering/invite-someone/invite-someone.component.spec.ts
@@ -80,9 +80,9 @@ describe('InviteSomeoneComponent', () => {
         let param = { value: someone, valid: isValid };
         let blandPageDetails = new BlandPageDetails(
             'Return to my pin',
-            '<h1 class="h1 text-center">Invite sent</h1>' +
+            '<h1 class="title text-lowercase">Invitation Sent</h1>' +
             // tslint:disable-next-line:max-line-length
-            `<p class="text text-center">${someone.firstname.slice(0, 1).toUpperCase()}${someone.firstname.slice(1).toLowerCase()} ${someone.lastname.slice(0, 1).toUpperCase()}. has been notified.</p>`,
+            `<p>${someone.firstname.slice(0, 1).toUpperCase()}${someone.firstname.slice(1).toLowerCase()} ${someone.lastname.slice(0, 1).toUpperCase()}. has been notified.</p>`,
             BlandPageType.Text,
             BlandPageCause.Success,
             `gathering/${gatheringId}`

--- a/src/app/components/pin-details/gathering/invite-someone/invite-someone.component.ts
+++ b/src/app/components/pin-details/gathering/invite-someone/invite-someone.component.ts
@@ -49,9 +49,9 @@ export class InviteSomeoneComponent implements OnInit {
                 success => {
                     let bpd = new BlandPageDetails(
                         'Return to my pin',
-                        '<h1 class="h1 text-center">Invite sent</h1>' +
+                        '<h1 class="title text-lowercase">Invitation Sent</h1>' +
                         // tslint:disable-next-line:max-line-length
-                        `<p class="text text-center">${someone.firstname.slice(0, 1).toUpperCase()}${someone.firstname.slice(1).toLowerCase()} ${someone.lastname.slice(0, 1).toUpperCase()}. has been notified.</p>`,
+                        `<p>${someone.firstname.slice(0, 1).toUpperCase()}${someone.firstname.slice(1).toLowerCase()} ${someone.lastname.slice(0, 1).toUpperCase()}. has been notified.</p>`,
                         BlandPageType.Text,
                         BlandPageCause.Success,
                         `gathering/${this.gatheringId}`

--- a/src/app/components/pin-details/say-hi/say-hi.component.ts
+++ b/src/app/components/pin-details/say-hi/say-hi.component.ts
@@ -72,9 +72,9 @@ export class SayHiComponent implements OnInit {
 
   private doSayHi() {
     // tslint:disable-next-line:max-line-length
-    let templateText =  `<h1 class="title">${this.isGathering ? 'Host contacted' : 'Success!'}</h1>`;
-    let notificationText = (this.isGathering) ? `${this.pin.firstName} ${this.pin.lastName.slice(0, 1)}. has been notified` 
-                                              : `You just said hi to ${this.pin.firstName} ${this.pin.lastName.slice(0, 1)}.`;
+    let templateText =  `<h1 class="title text-lowercase">${this.isGathering ? 'Host contacted' : 'Success!'}</h1>`;
+    let notificationText = (this.isGathering) ? `<p>${this.pin.firstName} ${this.pin.lastName.slice(0, 1)}. has been notified</p>`
+                                              : `<p>You just said hi to ${this.pin.firstName} ${this.pin.lastName.slice(0, 1)}.</p>`;
     let bpd = new BlandPageDetails(
       'Return to map',
       templateText + notificationText,
@@ -95,7 +95,7 @@ export class SayHiComponent implements OnInit {
   handleError() {
     let bpd = new BlandPageDetails();
     bpd.blandPageCause = BlandPageCause.Error;
-    bpd.content = '<h1 class="title">Sorry!</h1>We are unable to send your email at this time.';
+    bpd.content = '<h1 class="title text-lowercase">Sorry!</h1><p>We are unable to send your email at this time.</p>';
     bpd.goToState = this.isGathering ? '/gathering/' + this.pin.gathering.groupId : '/person/' + this.pin.participantId;
     bpd.buttonText = 'Return to details page';
     this.blandPageService.primeAndGo(bpd);

--- a/src/app/services/pin.service.ts
+++ b/src/app/services/pin.service.ts
@@ -208,7 +208,7 @@ export class PinService extends SmartCacheableService<PinSearchResultsDto, Searc
 
         let memberSaidHi = new BlandPageDetails(
           'Return to map',
-          '<div class="text text-center">Success!</div>',
+          '<h1 class="title text-lowercase">Success!</h1>',
           BlandPageType.Text,
           BlandPageCause.Success,
           ''


### PR DESCRIPTION
As a Connect user or host, I should see confirmation screens that match the approved design when I transact with other users.

---

All I did here was look for instances of `BlandPageType.Text` and fixed the markup so it would appear. In _many_ of these cases, there's really no easy way to make the confirmation page appear. And that's problematic for passing this on to QA, so I'm open to suggestions. (Perhaps this should sit here until all of the confirmation screens are working properly?)