### PR TITLE
Feature/us7915 text layout cleanup

### DIFF
--- a/src/app/components/add-me-to-map/add-me-to-map.component.html
+++ b/src/app/components/add-me-to-map/add-me-to-map.component.html
@@ -14,7 +14,7 @@
       <crds-content-block id="finderAddMeToMapText"></crds-content-block>
       <form novalidate [formGroup]="addMeToMapForm" (ngSubmit)="onSubmit(addMeToMapForm)">
         <address-form class="push-top" [parentForm]="addMeToMapForm" groupName="addressForm" [isFormSubmitted]="submissionError" [address]="userData.address"></address-form>
-        <footer class="page-footer page-footer-vertical">
+        <footer class="push-top btn-group-vertical">
           <button type="submit" [disabled]="addMeToMapForm.invalid || submitting" class="btn btn-secondary">Add me to the map</button>
           <button type="button" (click)="closeClick()" class="btn btn-link btn-default">Cancel</button>
         </footer>

--- a/src/app/components/authentication/authentication.component.css
+++ b/src/app/components/authentication/authentication.component.css
@@ -1,7 +1,0 @@
-.form__helpers {
-  margin-right: .25em;
-}
-
-#login-exception {
-  margin-top: 0em;
-}

--- a/src/app/components/authentication/authentication.component.html
+++ b/src/app/components/authentication/authentication.component.html
@@ -1,5 +1,5 @@
-<div heading="Sign In" class="content-middle">
-  <header class="component-header">Sign In</header>
+<div heading="Sign In" class="content-middle connect-white-bg">
+  <header class="component-header push-top">Sign In</header>
 
   <hr class="flush-top">
 

--- a/src/app/components/authentication/authentication.component.ts
+++ b/src/app/components/authentication/authentication.component.ts
@@ -11,8 +11,7 @@ import { CookieService, CookieOptionsArgs } from 'angular2-cookie/core';
 
 @Component({
   selector: 'app-authentication',
-  templateUrl: 'authentication.component.html',
-  styleUrls: ['authentication.component.css']
+  templateUrl: 'authentication.component.html'
 })
 export class AuthenticationComponent implements OnInit {
   public buttonText: string = 'Next';

--- a/src/app/components/getting-started/getting-started.component.html
+++ b/src/app/components/getting-started/getting-started.component.html
@@ -29,18 +29,18 @@
     <!-- Add Me To The Map Text/Button -->
     <crds-content-block id="finderGettingStartedAddToMap"></crds-content-block>
 
-    <div class="row soft-bottom soft-quarter-top">
-      <div class="col-xs-12 col-sm-4 col-sm-offset-4 btn-group">
-        <a routerLink="/add-me-to-the-map" class="btn btn-primary btn-block">Add me to map</a>
+    <div class="soft-bottom soft-quarter-top">
+      <div class="btn-group">
+        <a routerLink="/add-me-to-the-map" class="btn btn-primary">Add me to map</a>
       </div>
     </div>
 
     <!-- Host Text/Buttons -->
     <crds-content-block id="finderGettingStartedHost"></crds-content-block>
-    <div class="row push-bottom soft-bottom">
-      <div class="col-xs-12 col-sm-4 col-sm-offset-4 btn-group">
-        <a routerLink="/host-signup" class="btn btn-primary btn-block">Sign up</a>
-        <a routerLink="/whats-a-host" class="btn btn-default btn-outline btn-block">What's a host</a>
+    <div class="push-bottom soft-bottom">
+      <div class="btn-group">
+        <a routerLink="/host-signup" class="btn btn-primary">Sign up</a>
+        <a routerLink="/whats-a-host" class="btn btn-default btn-outline">What's a host</a>
       </div>
     </div>
   </div>

--- a/src/app/components/getting-started/getting-started.component.html
+++ b/src/app/components/getting-started/getting-started.component.html
@@ -1,8 +1,8 @@
-<div class="content-middle">
+<div class="content-middle connect-white-bg">
   <!--<div class="content-middle">-->
 
     <!-- Intro Text -->
-    <crds-content-block id="finderGettingStarted" class="text-center"></crds-content-block>
+    <crds-content-block id="finderGettingStarted"></crds-content-block>
 
     <!-- People -->
     <!--<div class="people push-ends">
@@ -27,16 +27,20 @@
     </div>-->
 
     <!-- Add Me To The Map Text/Button -->
-    <crds-content-block id="finderGettingStartedAddToMap" class="text-center"></crds-content-block>
+    <crds-content-block id="finderGettingStartedAddToMap"></crds-content-block>
 
-    <div class="btn-group-vertical">
-      <a routerLink="/add-me-to-the-map" class="btn btn-secondary">Add me to map</a>
+    <div class="row soft-bottom soft-quarter-top">
+      <div class="col-xs-12 col-sm-4 col-sm-offset-4 btn-group">
+        <a routerLink="/add-me-to-the-map" class="btn btn-primary btn-block">Add me to map</a>
+      </div>
     </div>
 
     <!-- Host Text/Buttons -->
-    <crds-content-block id="finderGettingStartedHost" class="text-center"></crds-content-block>
-    <div class="btn-group-vertical">
-      <a routerLink="/host-signup" class="btn btn-secondary">Sign up</a>
-      <a routerLink="/whats-a-host" class="btn btn-secondary">What's a host</a>
+    <crds-content-block id="finderGettingStartedHost"></crds-content-block>
+    <div class="row push-bottom soft-bottom">
+      <div class="col-xs-12 col-sm-4 col-sm-offset-4 btn-group">
+        <a routerLink="/host-signup" class="btn btn-primary btn-block">Sign up</a>
+        <a routerLink="/whats-a-host" class="btn btn-default btn-outline btn-block">What's a host</a>
+      </div>
     </div>
   </div>

--- a/src/app/components/host-application/host-application.component.html
+++ b/src/app/components/host-application/host-application.component.html
@@ -2,7 +2,7 @@
     <div class="container-fluid">
         <div class="fauxdal-content centered-form-group text-left">
             <form novalidate [formGroup]="hostForm" (ngSubmit)="onSubmit(hostForm)">
-                <h1 id="host-now-title" class="title text-lowercase">Host now!</h1>
+                <h1 id="host-now-title" class="title">Host now!</h1>
                 <br>
                 <div>Tell us where you want to meet and what you want to do.</div>
                 <br>

--- a/src/app/components/list-view/list-view.component.html
+++ b/src/app/components/list-view/list-view.component.html
@@ -1,6 +1,6 @@
 <div class="container-fluid connect-white-bg">
   <div *ngIf="isMyStuffView()">
-    <h2 class="title text-lowercase" *ngIf="isMyStuffView()"><crds-content-block id="finderMyStuff"></crds-content-block></h2>
+    <h2 class="title" *ngIf="isMyStuffView()"><crds-content-block id="finderMyStuff"></crds-content-block></h2>
     <hr>
   </div>
 

--- a/src/app/components/map-footer/map-footer.component.html
+++ b/src/app/components/map-footer/map-footer.component.html
@@ -1,9 +1,9 @@
 <input type="button"
-      class="btn btn-sm btn-primary"
+      class="btn btn-primary"
       value="Get started"
       (click)="gettingStartedBtnClicked()">
 <input type="button"
-      class="btn btn-sm btn-primary"
+      class="btn btn-primary"
       value="My stuff"
       [ngClass]="{'active': state.myStuffActive }"
       (click)="myStuffBtnClicked()">

--- a/src/app/components/pin-details/gathering/gathering-requests/gathering-requests.component.spec.ts
+++ b/src/app/components/pin-details/gathering/gathering-requests/gathering-requests.component.spec.ts
@@ -88,7 +88,7 @@ describe('GatheringRequestsComponent', () => {
         let expectedBPD = new BlandPageDetails(
             'Return to my pin',
             // tslint:disable-next-line:max-line-length
-            '<h1 class="title text-lowercase">Request accepted</h1><p>Joe K. has been notified.</p>',
+            '<h1 class="title">Request accepted</h1><p>Joe K. has been notified.</p>',
             BlandPageType.Text,
             BlandPageCause.Success,
             'gathering/' + comp.pin.gathering.groupId
@@ -109,7 +109,7 @@ describe('GatheringRequestsComponent', () => {
         let expectedBPD = new BlandPageDetails(
             'Return to my pin',
             // tslint:disable-next-line:max-line-length
-            '<h1 class="title text-lowercase">Request Denied</h1><p>Joe K. has been notified.</p>',
+            '<h1 class="title">Request Denied</h1><p>Joe K. has been notified.</p>',
             BlandPageType.Text,
             BlandPageCause.Success,
             'gathering/' + comp.pin.gathering.groupId

--- a/src/app/components/pin-details/gathering/gathering-requests/gathering-requests.component.ts
+++ b/src/app/components/pin-details/gathering/gathering-requests/gathering-requests.component.ts
@@ -57,9 +57,9 @@ export class GatheringRequestsComponent implements OnInit {
         let templateText;
         let bpd;
         if (approve) {
-          templateText = '<h1 class="title text-lowercase">Request accepted</h1>';
+          templateText = '<h1 class="title">Request accepted</h1>';
         } else {
-          templateText = '<h1 class="title text-lowercase">Request Denied</h1>';
+          templateText = '<h1 class="title">Request Denied</h1>';
         }
         // tslint:disable-next-line:max-line-length
         templateText += `<p>${inquiry.firstName} ${inquiry.lastName.slice(0, 1)}. has been notified.</p>`;

--- a/src/app/components/pin-details/gathering/gathering.html
+++ b/src/app/components/pin-details/gathering/gathering.html
@@ -1,4 +1,4 @@
-<div *ngIf="ready" class="container-fluid connect-container">
+<div *ngIf="ready">
   <div class="pin-details-dark dark-theme"
        [ngClass]="{ host_plain: !isInGathering && !isPinOwner }">
 

--- a/src/app/components/pin-details/gathering/invite-someone/invite-someone.component.spec.ts
+++ b/src/app/components/pin-details/gathering/invite-someone/invite-someone.component.spec.ts
@@ -80,7 +80,7 @@ describe('InviteSomeoneComponent', () => {
         let param = { value: someone, valid: isValid };
         let blandPageDetails = new BlandPageDetails(
             'Return to my pin',
-            '<h1 class="title text-lowercase">Invitation Sent</h1>' +
+            '<h1 class="title">Invitation Sent</h1>' +
             // tslint:disable-next-line:max-line-length
             `<p>${someone.firstname.slice(0, 1).toUpperCase()}${someone.firstname.slice(1).toLowerCase()} ${someone.lastname.slice(0, 1).toUpperCase()}. has been notified.</p>`,
             BlandPageType.Text,

--- a/src/app/components/pin-details/gathering/invite-someone/invite-someone.component.ts
+++ b/src/app/components/pin-details/gathering/invite-someone/invite-someone.component.ts
@@ -49,7 +49,7 @@ export class InviteSomeoneComponent implements OnInit {
                 success => {
                     let bpd = new BlandPageDetails(
                         'Return to my pin',
-                        '<h1 class="title text-lowercase">Invitation Sent</h1>' +
+                        '<h1 class="title">Invitation Sent</h1>' +
                         // tslint:disable-next-line:max-line-length
                         `<p>${someone.firstname.slice(0, 1).toUpperCase()}${someone.firstname.slice(1).toLowerCase()} ${someone.lastname.slice(0, 1).toUpperCase()}. has been notified.</p>`,
                         BlandPageType.Text,

--- a/src/app/components/pin-details/person/person.html
+++ b/src/app/components/pin-details/person/person.html
@@ -1,4 +1,4 @@
-<div class="connect-container container-fluid">
+<div>
   <div class="pin-details-dark person">
     <div class="media media-dark border-bottom soft-bottom push-bottom">
       <profile-picture imageClass="media-object img-size-6" wrapperClass="media-img-wrapper" [contactId]="pin.contactId"></profile-picture>

--- a/src/app/components/pin-details/say-hi/say-hi.component.ts
+++ b/src/app/components/pin-details/say-hi/say-hi.component.ts
@@ -72,7 +72,7 @@ export class SayHiComponent implements OnInit {
 
   private doSayHi() {
     // tslint:disable-next-line:max-line-length
-    let templateText =  `<h1 class="title text-lowercase">${this.isGathering ? 'Host contacted' : 'Success!'}</h1>`;
+    let templateText =  `<h1 class="title">${this.isGathering ? 'Host contacted' : 'Success!'}</h1>`;
     let notificationText = (this.isGathering) ? `<p>${this.pin.firstName} ${this.pin.lastName.slice(0, 1)}. has been notified</p>`
                                               : `<p>You just said hi to ${this.pin.firstName} ${this.pin.lastName.slice(0, 1)}.</p>`;
     let bpd = new BlandPageDetails(
@@ -95,7 +95,7 @@ export class SayHiComponent implements OnInit {
   handleError() {
     let bpd = new BlandPageDetails();
     bpd.blandPageCause = BlandPageCause.Error;
-    bpd.content = '<h1 class="title text-lowercase">Sorry!</h1><p>We are unable to send your email at this time.</p>';
+    bpd.content = '<h1 class="title">Sorry!</h1><p>We are unable to send your email at this time.</p>';
     bpd.goToState = this.isGathering ? '/gathering/' + this.pin.gathering.groupId : '/person/' + this.pin.participantId;
     bpd.buttonText = 'Return to details page';
     this.blandPageService.primeAndGo(bpd);

--- a/src/app/components/register/register.component.html
+++ b/src/app/components/register/register.component.html
@@ -1,5 +1,5 @@
-<div class="content-middle" heading="Register">
-  <header class="component-header">Register An Account</header>
+<div class="content-middle connect-white-bg" heading="Register">
+  <header class="component-header push-top">Register An Account</header>
 
   <hr class="flush-top">
 

--- a/src/app/components/search-local/search-local.component.html
+++ b/src/app/components/search-local/search-local.component.html
@@ -1,3 +1,3 @@
 <button *ngIf="active"
-        class="btn btn-sm btn-secondary"
+        class="btn btn-secondary"
         (click)="doLocalSearch()">Update Results</button>

--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -31,7 +31,7 @@
           <use xlink:href="/assets/svgs/icons.svg#chevron-left"></use>
         </svg>
       </a>
-      <h1 *ngIf="state.pageHeader.title" class="text-lowercase">
+      <h1 *ngIf="state.pageHeader.title">
         {{ state.pageHeader.title }}
       </h1>
     </div>

--- a/src/app/services/bland-page.service.ts
+++ b/src/app/services/bland-page.service.ts
@@ -32,7 +32,7 @@ export class BlandPageService {
     public goToDefaultError(goToRoute: string) {
         this.blandPageDetails = new BlandPageDetails(
             'back',
-            '<h1 class="title text-lowercase">OOPS</h1><p>Something went wrong.</p>',
+            '<h1 class="title">OOPS</h1><p>Something went wrong.</p>',
             BlandPageType.Text,
             BlandPageCause.Error,
             goToRoute

--- a/src/app/services/pin.service.ts
+++ b/src/app/services/pin.service.ts
@@ -208,7 +208,7 @@ export class PinService extends SmartCacheableService<PinSearchResultsDto, Searc
 
         let memberSaidHi = new BlandPageDetails(
           'Return to map',
-          '<h1 class="title text-lowercase">Success!</h1>',
+          '<h1 class="title">Success!</h1>',
           BlandPageType.Text,
           BlandPageCause.Success,
           ''

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -128,7 +128,6 @@ app-add-me-to-map {
     align-items: center;
     display: flex;
     justify-content: center;
-    padding-top: 3rem;
   }
 
   .fauxdal-content {

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -4,6 +4,7 @@
 
 body {
   -webkit-font-smoothing: initial;
+  background: $cr-gray-lighter;
 }
 
 #toast-container {
@@ -421,5 +422,18 @@ search-local {
         box-shadow: none;
       }
     }
+  }
+}
+
+.connect-white-bg {
+  background: $cr-white;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+
+  @media (min-width: $screen-sm) {
+    box-shadow: 0 0 10px 0 $cr-gray-light;
+    margin: 0 auto;
+    padding: 1rem 2rem;
+    width: $container-tablet;
   }
 }

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -383,13 +383,9 @@ app-map-footer {
 search-local {
   display: block;
   position: absolute;
-  top: 85px;
-  right: 1rem;
+  bottom: 60px;
+  left: calc(50% - 66px); // half screen width minus half of the button width
   z-index: 4;
-
-  @media (min-width: $screen-xs) {
-    top: 93px;
-  }
 }
 
 // 🚨 Temp fix - Need higher contrast for active states on btns (to be revisited).

--- a/src/styles/components/_media-objects.scss
+++ b/src/styles/components/_media-objects.scss
@@ -5,19 +5,6 @@
   }
 }
 
-.connect-white-bg {
-  background: $cr-white;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-
-  @media (min-width: $screen-sm) {
-    box-shadow: 0 0 10px 0 $cr-gray-light;
-    margin: 0 auto;
-    padding: 1rem 2rem;
-    width: $container-tablet;
-  }
-}
-
 .connect-list-footer {
   margin-right: -1rem;
   margin-left: -1rem;


### PR DESCRIPTION
- Text should be left-aligned everywhere but fauxdals (where they remain center aligned)
- Map buttons should be default size (remove `.btn-sm` class)
- "Update results" button has moved to the bottom center of the map screen
- The first letter of headers are capitalized 
- Using the gray background/box-shadow layout throughout the application (`/getting-started`, `/sign-in`, `registration`, etc.)

Corresponds with crds-styles/development

----------
On screens where the content is centered with a white background, change this so it matches the /list view (i.e., has light gray background with slight box-shadow around it)
On fauxdals where the content is vertically centered, move the content slightly up. The vertical centering creates an optical illusion on the content.
Increase spacing on between the form and submit button on Add me to Map screen
Fauxdals should stay entirely center aligned
Remove .btn-sm from map buttons
Update results buttons to be centered on map (consider lower placement on mobile?) https://invis.io/VRAO3U5ST#/230153224_V2c-My-Stuff-A
