### PR TITLE
DEXXXX Revert CRDS NG2 Content Block

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "bootstrap-sass": "3.3.7",
     "codelyzer": "2.0.0",
     "copy-webpack-plugin": "4.0.0",
-    "crds-ng2-content-block": "crdschurch/crds-ng2-content-block#development",
+    "crds-ng2-content-block": "1.0.2",
     "css-loader": "0.25.0",
     "css-to-string-loader": "0.1.2",
     "dotenv-webpack": "1.4.0",

--- a/src/app/components/host-application/host-application.component.ts
+++ b/src/app/components/host-application/host-application.component.ts
@@ -52,13 +52,8 @@ export class HostApplicationComponent implements OnInit {
     this.homeAddress = this.userData.address;
     this.groupAddress = new Address(null, '', '', '', '', '', null, null, null, null);
 
-    let content: string = '';
-    this.content.getContent('defaultGatheringDesc').subscribe(x => {
-       content = x.content;
-    });
-
     let gatheringDescriptionPlaceholder: string =
-        this.hlpr.stripHtmlFromString(content);
+        this.hlpr.stripHtmlFromString(this.content.getContent('defaultGatheringDesc'));
 
     this.hostForm = new FormGroup({
       isHomeAddress: new FormControl(true, [Validators.required]),


### PR DESCRIPTION
Due to the number of instances within `crds-connect` relying on an old implementation of the `getContent()` method in the `crds-ng2-content-block` package, this PR reverts that dependency to `v1.0.2`. 

---

Revert "get content as observable"

This reverts commit 65fc3980bb79fd7164712257ddaa1cfeb82a5c75.