### PR TITLE
DE3414 - Pin details mobile bg

### DIFF
--- a/src/app/components/pin-details/pin-details.html
+++ b/src/app/components/pin-details/pin-details.html
@@ -1,4 +1,4 @@
-<div class="connect-white-bg container" [class.is-gathering]="isGatheringPin">
+<div [class.is-gathering]="isGatheringPin">
   <gathering *ngIf="isGatheringPin" [user]="user" [pin]="pin" [isLoggedIn]="isLoggedIn" [isPinOwner]="isPinOwner"></gathering>
   <person *ngIf="!isGatheringPin" [user]="user" [pin]="pin" [isLoggedIn]="isLoggedIn" [isPinOwner]="isPinOwner"></person>
 </div>


### PR DESCRIPTION
Remove conflicting class to remove padding.

------
The dark background on the pin details (individual & host) should but full width on mobile.

https://www.dropbox.com/s/o17556l8xome1gc/Screenshot%202017-04-28%2014.42.56.png?dl=0