### PR TITLE
DE3417 - Button layout on host edit page

### DIFF
--- a/src/app/components/host-application/host-application.component.html
+++ b/src/app/components/host-application/host-application.component.html
@@ -63,9 +63,9 @@
           <div class="text-muted font-size-smaller">
             <crds-content-block id="hintsForGatheringDesc"></crds-content-block>
           </div>
-          <footer class="text-center btn-group-vertical">
+          <footer class="btn-group">
             <button type="submit" class="btn btn-secondary">Submit</button>
-            <button type="button" (click)="closeClick()" class="btn btn-link btn-default">Cancel</button>
+            <button type="button" (click)="closeClick()" class="btn btn-outline btn-default">Cancel</button>
           </footer>
           <div *ngIf="submissionError" class="alert alert-danger">
             <crds-content-block id="generalError"></crds-content-block>


### PR DESCRIPTION
Move buttons to left-aligned, inline with each other. Change the default button to the gray outline button.


----------
On the host edit screen, the buttons are centered and stacked vertically. They should be inline and aligned to the left (or right), like other forms buttons on the site.

https://projects.invisionapp.com/d/main#/console/9595176/209360074/preview

I'm also not sure the "Cancel" button should be a btn-link, I'd lean towards an outline button here but I'll let Rob make that call. Regardless, I'd like us to pick a "Cancel" button pattern and make that consistent everywhere.