### PR TITLE
DE3421 - Fix phone number text on host signup page.

### DIFF
--- a/src/app/components/host-application/host-application.component.html
+++ b/src/app/components/host-application/host-application.component.html
@@ -40,10 +40,10 @@
           <div class="control-label">BEST REACHED AT:</div>
           <div class="row">
             <div class="form-group col-xs-12">
-              <label class="sr-only" for="contactNumber">BEST REACHED AT:</label>
-              <input tabindex="1" type="text" onlyTheseKeys="[0-9]" maxlength="10" class="form-control push-half-top" placeholder="Contact Number"
-                id="contactNumber" formControlName="contactNumber" name="contactNumber">
-              <p class="error help-block" *ngIf="isFormSubmitted && !hostForm.controls['contactNumber'].valid">Contact number is invalid!!</p>
+              <label class="sr-only" for="phoneNumber">BEST REACHED AT:</label>
+              <input tabindex="1" type="text" onlyTheseKeys="[0-9]" maxlength="10" class="form-control push-half-top" placeholder="Phone number"
+                id="phoneNumber" formControlName="contactNumber" name="phoneNumber">
+              <p class="error help-block" *ngIf="isFormSubmitted && !hostForm.controls['contactNumber'].valid">Phone number is invalid!!</p>
             </div>
           </div>
           <br>

--- a/src/app/components/host-application/host-application.component.html
+++ b/src/app/components/host-application/host-application.component.html
@@ -40,9 +40,9 @@
           <div class="control-label">BEST REACHED AT:</div>
           <div class="row">
             <div class="form-group col-xs-12">
-              <label class="sr-only" for="phoneNumber">BEST REACHED AT:</label>
+              <label class="sr-only" for="contactNumber">BEST REACHED AT:</label>
               <input tabindex="1" type="text" onlyTheseKeys="[0-9]" maxlength="10" class="form-control push-half-top" placeholder="Phone number"
-                id="phoneNumber" formControlName="contactNumber" name="phoneNumber">
+                id="contactNumber" formControlName="contactNumber" name="contactNumber">
               <p class="error help-block" *ngIf="isFormSubmitted && !hostForm.controls['contactNumber'].valid">Phone number is invalid!!</p>
             </div>
           </div>


### PR DESCRIPTION
On the host signup page, the phone number field reads "Contact Number" which is confusing. We're asking the user for a phone number so it should read "Phone Number". Don't forget to correct the error message too.