### PR TITLE
DE3411 - Invite form btn skips

### DIFF
--- a/src/app/components/pin-details/gathering/invite-someone/invite-someone.html
+++ b/src/app/components/pin-details/gathering/invite-someone/invite-someone.html
@@ -6,8 +6,7 @@
     <div class="form-group col-xs-6">
       <!--FIRST NAME-->
       <label class="sr-only" for="firstname">First Name</label>
-      <input tabindex="1"
-             type="text"
+      <input type="text"
              class="form-control"
              maxlength="30"
              placeholder="First Name"
@@ -21,8 +20,7 @@
     <!--LAST NAME-->
     <div class="form-group col-xs-6">
       <label class="sr-only" for="lastname">Last Name</label>
-      <input tabindex="2"
-             type="text"
+      <input type="text"
              class="form-control"
              maxlength="30"
              placeholder="Last Name"
@@ -39,8 +37,7 @@
     <div class="col-xs-12">
       <div class="form-group">
         <label class="sr-only" for="email">Email</label>
-        <input tabindex="3"
-               type="email"
+        <input type="email"
                class="form-control"
                maxlength="100"
                placeholder="Email"


### PR DESCRIPTION
Remove tabindex.

Test by signing in as a Gathering Host Cool Person Supreme, and going to the Gathering pin details page. Enter info in the "Invite Someone" section and tab around. The submit button should be included in the appropriate flow.

---
When completing the invite form on the host details page, tabbing skips the submit button.

http://quick.as/nmV1ID7wo