### PR TITLE
Defect/de3528 remove me fauxdal

### DIFF
--- a/src/styles/components/_fauxdals.scss
+++ b/src/styles/components/_fauxdals.scss
@@ -13,6 +13,8 @@
   bottom: 0;
   left: 0;
   z-index: 5;
+  overflow-y: scroll;
+  overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
 }
 
@@ -28,7 +30,7 @@
 
     position: absolute;
     top: 1rem;
-    right: 1rem;
+    right: 2rem;
 
     a {
       color: $cr-white;

--- a/src/styles/components/_fauxdals.scss
+++ b/src/styles/components/_fauxdals.scss
@@ -16,6 +16,10 @@
   overflow-y: scroll;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
+
+  &::-webkit-scrollbar {
+    background-color: darken($cr-blue, 15);
+  }
 }
 
 .fauxdal {

--- a/src/styles/components/_fauxdals.scss
+++ b/src/styles/components/_fauxdals.scss
@@ -13,7 +13,6 @@
   bottom: 0;
   left: 0;
   z-index: 5;
-  overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 }
 

--- a/src/styles/components/_fauxdals.scss
+++ b/src/styles/components/_fauxdals.scss
@@ -17,8 +17,8 @@
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
 
-  &::-webkit-scrollbar {
-    background-color: darken($cr-blue, 15);
+  &::-webkit-scrollbar-track-piece {
+    background-color: transparent;
   }
 }
 


### PR DESCRIPTION
All fauxdals look gross on PC - because they don't hide the scrollbar. I've hidden overflow-x and made the scrollbar transparent on `-webkit` based browsers so it's not ugly. Other browsers are SOL.

To test on a Mac, open your System Preferences > General > and select Always Scrolling

Corresponds with crds-styles/development