### PR TITLE
DE3527 - Pin Details Container Too Wide

### DIFF
--- a/src/app/components/pin-details/pin-details.html
+++ b/src/app/components/pin-details/pin-details.html
@@ -1,4 +1,4 @@
-<div class="connect-container container" [class.is-gathering]="isGatheringPin">
+<div class="connect-container container-fluid" [class.is-gathering]="isGatheringPin">
   <gathering *ngIf="isGatheringPin || isSmallGroupPin" [user]="user" [pin]="pin" [isLoggedIn]="isLoggedIn" [isPinOwner]="isPinOwner"></gathering>
   <person *ngIf="!isGatheringPin && !isSmallGroupPin" [user]="user" [pin]="pin" [isLoggedIn]="isLoggedIn" [isPinOwner]="isPinOwner"></person>
 </div>


### PR DESCRIPTION
Fix pin details container for maestro.

This was only an issue in Maestro, but because it affects code in Connect, should be tested locally in both Maestro and Connect.

---

No corresponding PRs.