### PR TITLE
DE3526 - List view layout jacked up

### DIFF
--- a/src/app/components/list-view/list-view.component.html
+++ b/src/app/components/list-view/list-view.component.html
@@ -1,4 +1,4 @@
-<div class="container-fluid connect-container">
+<div class="connect-container">
   <div *ngIf="isMyStuffView()">
     <h2 class="title" *ngIf="isMyStuffView()"><crds-content-block id="finderMyStuff"></crds-content-block></h2>
     <hr>


### PR DESCRIPTION
Remove `.container-fluid` from the layout because it breaks everything. (We should probably review how we're using this class in the future because it feels... inappropriate?)

Test /connect and maestro/connect locally.

---
Sections with gray backgrounds on the List View of /connect are broken (shifted up and to the left of intended layout). 
 