### PR TITLE
DE3541 - Gathering pin details page layout

### DIFF
--- a/src/app/components/list-view/list-view.component.html
+++ b/src/app/components/list-view/list-view.component.html
@@ -1,4 +1,4 @@
-<div class="container-fluid connect-container">
+<div class="connect-container">
   <div *ngIf="isMyStuffView()">
     <h2 class="title" *ngIf="isMyStuffView()"><crds-content-block id="finderMyStuff"></crds-content-block></h2>
     <hr>

--- a/src/app/components/pin-details/pin-details.html
+++ b/src/app/components/pin-details/pin-details.html
@@ -1,4 +1,4 @@
-<div class="connect-container container-fluid" [class.is-gathering]="isGatheringPin">
+<div class="connect-container" [class.is-gathering]="isGatheringPin">
   <gathering *ngIf="isGatheringPin || isSmallGroupPin" [user]="user" [pin]="pin" [isLoggedIn]="isLoggedIn" [isPinOwner]="isPinOwner"></gathering>
   <person *ngIf="!isGatheringPin && !isSmallGroupPin" [user]="user" [pin]="pin" [isLoggedIn]="isLoggedIn" [isPinOwner]="isPinOwner"></person>
 </div>


### PR DESCRIPTION
Remove `.container-fluid` from gathering pin details page so the black section doesn't expand past the rest of the layout.

Test both maestro and normal /connect. **Keep yer eyes peeled - this fix *may* have introduced regressions (though I didn't find any).**

---
Navigate to a gathering  with participants. The black section at the top extends past the white sections beneath (by about 15px left and right).