### PR TITLE
DE3386 - Send invite button

### DIFF
--- a/src/app/components/pin-details/gathering/invite-someone/invite-someone.component.ts
+++ b/src/app/components/pin-details/gathering/invite-someone/invite-someone.component.ts
@@ -23,6 +23,7 @@ export class InviteSomeoneComponent implements OnInit {
     @Input() participantId: number;
 
     public inviteFormGroup: FormGroup;
+    public isFormSubmitted: boolean = false;
 
     constructor(private fb: FormBuilder,
         private router: Router,
@@ -41,6 +42,8 @@ export class InviteSomeoneComponent implements OnInit {
     }
 
     onSubmit({ value, valid }: { value: any, valid: boolean }) {
+        this.isFormSubmitted = true;
+
         if (valid) {
             let someone = new Person(value.firstname, value.lastname, value.email);
 

--- a/src/app/components/pin-details/gathering/invite-someone/invite-someone.html
+++ b/src/app/components/pin-details/gathering/invite-someone/invite-someone.html
@@ -14,7 +14,7 @@
              formControlName="firstname"
              name="firstname">
 
-      <p *ngIf="inviteFormGroup.controls['firstname'].touched && !inviteFormGroup.controls['firstname'].valid" class="error help-block">First Name is required!</p>
+      <p *ngIf="isFormSubmitted && !inviteFormGroup.controls['firstname'].valid" class="error help-block">First Name is required!</p>
     </div>
 
     <!--LAST NAME-->
@@ -28,7 +28,7 @@
              formControlName="lastname"
              name="lastname">
 
-      <p *ngIf="inviteFormGroup.controls['lastname'].touched && !inviteFormGroup.controls['lastname'].valid" class="error help-block">Last Name is required!</p>
+      <p *ngIf="isFormSubmitted && !inviteFormGroup.controls['lastname'].valid" class="error help-block">Last Name is required!</p>
     </div>
   </div>
 
@@ -45,10 +45,10 @@
                formControlName="email"
                name="email">
 
-        <p *ngIf="inviteFormGroup.controls['email'].touched && !inviteFormGroup.controls['email'].valid" class="error help-block">A valid email is required!</p>
+        <p *ngIf="isFormSubmitted && !inviteFormGroup.controls['email'].valid" class="error help-block">A valid email is required!</p>
       </div>
     </div>
   </div>
 
-  <button type="submit" [disabled]="inviteFormGroup.invalid" class="btn btn-secondary">Send Invite</button>
+  <button type="submit" class="btn btn-secondary">Send Invite</button>
 </form>


### PR DESCRIPTION
Update the submit button on the "send invite" form so it's never disabled and validates form fields after submission.

No corresponding PRs.

---
When I am looking at my Gathering (Logged in as a Host, viewing my Gathering Pin Details) the "Send Invite" button should always be clickable (mobile friendly) and show the appropriate error functionality