### PR TITLE
DE3528 - Remove me from map fauxdal

### DIFF
--- a/src/app/components/pin-details/person/remove-person-pin/remove-person-pin.component.ts
+++ b/src/app/components/pin-details/person/remove-person-pin/remove-person-pin.component.ts
@@ -35,6 +35,12 @@ export class RemovePersonPinComponent implements OnInit {
     this.pin = this.route.snapshot.data['pin'];
   }
 
+  public ngAfterViewInit() {
+    // This component is rendered within a fauxdal,
+    // so we need the following selector added to <body> element
+    document.querySelector('body').classList.add('fauxdal-open');
+  }
+
   public removePersonPin() {
     this.pinService.removePersonPin(this.pin.participantId).subscribe(
       () => {
@@ -73,11 +79,4 @@ export class RemovePersonPinComponent implements OnInit {
     console.log(this.pin);
     this.router.navigate(['/person/', this.pin.participantId, 'edit']);
   }
-
-
-
-
-
-
-
 }


### PR DESCRIPTION
Add class of .fauxdal-open to the body to prevent duplicate scrollbar from popping up.
No corresponding PR.

**Check out fauxdals locally in Maestro to account for the length of the footer (this is what caused the duplicate scrollbar)**

---
Peter re-opened this defect. Spotted a duplicate scrollbar on the "Remove me from map" fauxdal when using Chrome on PC. Defect not visible on other fauxdals in the application.