### PR TITLE
DE3668 - Pin details content overflows

### DIFF
--- a/src/styles/pages/_pin-details.scss
+++ b/src/styles/pages/_pin-details.scss
@@ -19,7 +19,7 @@
 
   &.person,
   &.host_plain {
-    height: 100vh;
+    min-height: 100vh;
     margin-bottom: -1rem;
   }
 }


### PR DESCRIPTION
Change the height of person/gathering pin details page from explicitly stated height to a min-height. This allows the content to increase the size of the container rather than causing additional content to overflow into the footer.

No other related PRs out there.