### PR TITLE
DE3747 - Getting Started Buttons

### DIFF
--- a/src/app/components/getting-started/getting-started.component.html
+++ b/src/app/components/getting-started/getting-started.component.html
@@ -28,7 +28,7 @@
     <crds-content-block id="finderGettingStartedAddToMap"></crds-content-block>
 
     <div class="soft-bottom soft-quarter-top">
-      <div class="btn-group btn-block-mobile">
+      <div class="btn-group full-width">
         <a routerLink="/add-me-to-the-map" class="btn btn-primary btn-block-mobile">Add me to map</a>
       </div>
     </div>
@@ -36,7 +36,7 @@
     <!-- Host Text/Buttons -->
     <crds-content-block id="finderGettingStartedHost"></crds-content-block>
     <div class="push-bottom soft-bottom">
-      <div class="btn-group btn-block-mobile">
+      <div class="btn-group full-width">
         <a routerLink="/host-signup" class="btn btn-primary btn-block-mobile">Sign up to host</a>
         <a routerLink="/whats-a-host" class="btn btn-default btn-outline btn-block-mobile">What's a host</a>
       </div>

--- a/src/app/components/list-footer/list-footer.component.html
+++ b/src/app/components/list-footer/list-footer.component.html
@@ -10,7 +10,7 @@
   <div *ngIf="isUserHostingAnyGatheringsOrGroups"
         class="bg-gray col-xs-12 push-top soft">
     <crds-content-block id="finderWantToHost"></crds-content-block>
-    <div class="btn-group btn-block-mobile">
+    <div class="btn-group full-width">
       <button class="btn btn-default btn-block-mobile" (click)="becomeAHostClicked()">Sign up</button>
       <button class="btn btn-default btn-block-mobile" (click)="whatsAHostBtnClicked()">What's a host?</button>
     </div>

--- a/src/app/components/no-results/no-results.component.html
+++ b/src/app/components/no-results/no-results.component.html
@@ -1,7 +1,7 @@
 <div class="connect-container connect-layout-container">
   <crds-content-block id="noSearchResults"></crds-content-block>
 
-  <div class="btn-group push-half-top btn-block-mobile">
+  <div class="btn-group push-half-top full-width">
     <button type="submit" id='btnAddToMap' class="btn btn-secondary btn-block-mobile"
             (click)="btnClickAddToMap();">Add me to the map</button>
     <button type="submit" id='becomeAHost' class="btn btn-secondary btn-block-mobile"

--- a/src/app/components/pin-details/person/remove-person-pin/remove-person-pin.component.html
+++ b/src/app/components/pin-details/person/remove-person-pin/remove-person-pin.component.html
@@ -17,7 +17,7 @@
 
       <br>
 
-      <footer class="page-footer btn-group-vertical btn-block-mobile">
+      <footer class="page-footer btn-group-vertical full-width">
         <button type="submit" id='btnRemovePersonPin' class="btn btn-secondary btn-block-mobile" (click)="removePersonPin();">Remove me from the map</button>
         <button type="submit" id='btnCancel' class="btn btn-outline btn-default btn-block-mobile" (click)="cancel();">Cancel</button>
       </footer>


### PR DESCRIPTION
Fix issue with mobile block buttons not taking up the appropriate space on the page. In response to:

> on the getting started page on iOS, the Host buttons bleeds into the footer