### PR TITLE
DE3754 - X Keyboard

### DIFF
--- a/src/app/components/search-bar/search-bar.component.html
+++ b/src/app/components/search-bar/search-bar.component.html
@@ -3,12 +3,13 @@
     <div class="input-group searchbar">
       <input type="text"
              class="form-control"
+             id="search-bar-input"
              [(ngModel)]="state.searchBarText"
              (keyup.enter)="onSearch(state.searchBarText)"
              (keyup)="searchKeyUp()"
              placeholder={{placeholderTextForSearchBar}}>
       <!--(keyup) = "searchKeyUp()"--> <!--This attribute belongs to the input above-->
-      <span class="form-control-clear form-control-feedback" [hidden]="isSearchClearHidden" (click)="state.searchBarText()">
+      <span class="form-control-clear form-control-feedback" [hidden]="isSearchClearHidden" (click)="resetSearchInput($event)">
         <svg class="icon icon-1" viewBox="0 0 256 256">
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#close"></use>
         </svg>

--- a/src/app/components/search-bar/search-bar.component.ts
+++ b/src/app/components/search-bar/search-bar.component.ts
@@ -92,8 +92,18 @@ export class SearchBarComponent implements OnChanges, OnInit {
     this.state.searchBarText = '';
   }
 
+  public resetSearchInput(event) {
+    event.preventDefault();
+    this.clearSearchText();
+    this.focusSearchInput();
+  }
+
   public searchKeyUp(){
     this.isSearchClearHidden = false;
+  }
+
+  public focusSearchInput() {
+    document.getElementById('search-bar-input').focus();
   }
 
 }


### PR DESCRIPTION
when clicking the X button to clear the search bar, the keyboard is dismissed

Note: this is relevant to Finder, the search input at the top had a clear icon added to them