### PR TITLE
US8554 - List view group attributes

### DIFF
--- a/src/app/components/list-entry/list-entry.component.html
+++ b/src/app/components/list-entry/list-entry.component.html
@@ -32,8 +32,8 @@
       <!--This functionality is being removed due to DE3433 and will be completed in USUS7759
      <span>JOINED BY {{count()}}</span>
      -->
-    </p>    
-    <p class="media-description">{{gatheringDescription()}}</p> 
+    </p>
+    <p class="media-description">{{gatheringDescription()}}</p>
 
   </div>
 </div>
@@ -64,18 +64,21 @@
     </h3>
     <p class="media-meta">
       <span *ngIf="pin?.gathering?.meetingDay != null">{{pin?.gathering?.meetingDay}} at {{ pin?.gathering?.meetingTime }}, {{pin?.gathering?.meetingFrequency}}</span>
-      <span *ngIf="pin?.gathering?.meetingDay == null">Flexible Meeting Time</span> 
+      <span *ngIf="pin?.gathering?.meetingDay == null">Flexible Meeting Time</span>
       <br>
       <span *ngIf="address.addressId !== 0">({{pin?.proximity |  number : '1.2-2' }} MI)</span>
-      <span *ngIf="address.addressId === 0">Online Group</span>       
+      <span *ngIf="address.addressId === 0">Online Group</span>
     </p>
-    <p class="media-description">
-      <strong>Category: </strong><span *ngFor="let category of pin?.gathering?.categories"> {{category}}<br></span>
-      <span *ngIf="pin?.gathering?.categories == null"><br></span>
-      <strong>Type: </strong> {{pin?.gathering?.groupType}}
-      <br>
-      <strong>Leader: </strong> {{pin?.gathering?.primaryContactFirstName}} {{pin?.gathering?.primaryContactLastName}}
-   </p>
+
+    <dl class="media-description">
+      <dt>Category:</dt>
+      <dd *ngFor="let category of pin?.gathering?.categories">{{category}}</dd>
+      <dd *ngIf="pin?.gathering?.categories == null">&nbsp;</dd>
+      <dt>Type:</dt>
+      <dd>{{pin?.gathering?.groupType}}</dd>
+      <dt>Leader:</dt>
+      <dd>{{pin?.gathering?.primaryContactFirstName}} {{pin?.gathering?.primaryContactLastName}}</dd>
+    </dl>
   </div>
 
 </div>

--- a/src/styles/components/_media-objects.scss
+++ b/src/styles/components/_media-objects.scss
@@ -11,3 +11,29 @@
   font-size: $font-size-base;
   font-weight: 600;
 }
+
+dl {
+  &.media-description {
+    font-size: $font-size-small;
+
+    dt:not(:first-child) {
+      margin-top: .5rem;
+    }
+
+    @media (min-width: $screen-xs) {
+      clear: both;
+
+      dt {
+        float: left;
+      }
+
+      dt:not(:first-child) {
+        margin-top: auto;
+      }
+
+      dd {
+        margin-left: 85px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Style the group attributes to the design.

No corresponding PRs.

---
The list view of the Finder tool needs to be updated to include styles for the additional groups attributes that will be added. List view on Connect currently looks like this:

For Groups, need to add the following:
Meeting day/time
Group category
Group detail
Group type
Group leader

Will look more like this: https://invis.io/68BRD8RXB#/234261457_02M-01a-Groups-List