### PR TITLE
Defect/de3795 group details formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "angulartics2": "2.2.1",
     "copyfiles": "1.0.0",
     "core-js": "2.4.1",
-    "crds-styles": "0.9.0",
+    "crds-styles": "crdschurch/crds-styles#development",
     "iframe-resizer": "3.5.9",
     "intl": "1.2.5",
     "moment": "2.17.0",

--- a/src/app/components/list-entry/list-entry.component.html
+++ b/src/app/components/list-entry/list-entry.component.html
@@ -72,7 +72,7 @@
 
     <dl class="media-description">
       <dt>Category:</dt>
-      <dd *ngFor="let category of pin?.gathering?.categories">{{category}}</dd>
+      <dd *ngFor="let category of pin?.gathering?.categories">{{category.replace(":", ": ")}}</dd>
       <dd *ngIf="pin?.gathering?.categories == null">&nbsp;</dd>
       <dt>Type:</dt>
       <dd>{{pin?.gathering?.groupType}}</dd>

--- a/src/app/components/pin-details/gathering/gathering.html
+++ b/src/app/components/pin-details/gathering/gathering.html
@@ -48,7 +48,7 @@
 
       <dl *ngIf="pin.pinType === pinType.SMALL_GROUP" class="group-meta-data border-top push-top">
         <dt>Category</dt>
-        <dd *ngFor="let category of pin?.gathering?.categories">{{category}}</dd>
+        <dd *ngFor="let category of pin?.gathering?.categories">{{category.replace(":", ": ")}}</dd>
 
         <dt>Where</dt>
         <dd>


### PR DESCRIPTION
Groups categories should have a space after ":", separating the group name from the group details.

Test by visiting the list view on `/connect` (categories should be visible here by default) and clicking into any list-entry to view gathering details categories.

No corresponding PRs.