### PR TITLE
US8620 - Start Group Markup

### DIFF
--- a/src/app/components/create-group/create-group-summary/create-group-summary.component.html
+++ b/src/app/components/create-group/create-group-summary/create-group-summary.component.html
@@ -1,7 +1,5 @@
-<div class="connect-container connect-layout-container">
-    <div>
-        <crds-content-block id="finderCreateGroupHeading"></crds-content-block>
-        <br />
-        <button type="submit" class="btn btn-block btn-primary push-half-top btn-block-mobile" [routerLink]="['page-1']">Create my group</button>
-    </div>
+<div class="connect-container connect-layout-container soft-sides">
+  <crds-content-block id="finderCreateGroupHeading"></crds-content-block>
+  <button type="submit" class="btn btn-primary push-half-top btn-block-mobile"
+          [routerLink]="['page-1']">Create my group</button>
 </div>

--- a/src/app/components/create-group/page-1/create-group-page-1.component.html
+++ b/src/app/components/create-group/page-1/create-group-page-1.component.html
@@ -1,7 +1,7 @@
 <div class="connect-container connect-layout-container">
-    <div class="row">
+    <div class="row soft-top">
         <div class="col-sm-12">
-            <p class="media-meta">STEP 1 OF 9</p>
+            <p class="media-meta flush-bottom">STEP 1 OF 9</p>
             <h3 class="media-heading">Group Category</h3>
             <hr>
             <crds-content-block id="groupToolCreateGroupCategoryHelp"></crds-content-block>
@@ -14,7 +14,7 @@
                     <button type="button" class="btn btn-option btn-flex btn-outline" [id]="category.name" [ngClass]="{active: category.selected}"
                         (click)="onSelect(category)" formControlName="{{category.name}}" value="{{category}}"
                         ngDefaultControl>
-                
+
                         <div class="text-left">{{ category.name }}</div>
                 </button>
                     <div>
@@ -40,7 +40,8 @@
                         <crds-content-block id="finderCategoriesInvalid"></crds-content-block>
                     </div>
                 </div>
-                <div class="col-xs-12 btn-block-mobile soft-ends">
+                <div class="soft-ends">
+                    <hr>
                     <button type="submit" class="btn btn-secondary btn-block-mobile pull-right">Next</button>
                     <button type="button" (click)="back()" class="btn btn-gray btn-default btn-block-mobile">Back</button>
                 </div>

--- a/src/app/components/create-group/page-1/create-group-page-1.component.html
+++ b/src/app/components/create-group/page-1/create-group-page-1.component.html
@@ -1,8 +1,8 @@
 <div class="connect-container connect-layout-container">
     <div class="row soft-top">
-        <div class="col-sm-12">
+        <div class="col-sm-12 soft-top">
             <p class="media-meta flush-bottom">STEP 1 OF 9</p>
-            <h3 class="media-heading">Group Category</h3>
+            <h3 class="media-heading font-family-condensed-extra text-uppercase">Group Category</h3>
             <hr>
             <crds-content-block id="groupToolCreateGroupCategoryHelp"></crds-content-block>
         </div>
@@ -17,7 +17,7 @@
 
                         <div class="text-left">{{ category.name }}</div>
                 </button>
-                    <div>
+                    <div class="help-block">
                         <i>{{category.desc}}</i>
                     </div>
 
@@ -42,7 +42,7 @@
                 </div>
                 <div class="soft-ends">
                     <hr>
-                    <button type="submit" class="btn btn-secondary btn-block-mobile pull-right">Next</button>
+                    <button type="submit" class="btn btn-primary btn-block-mobile pull-right">Next</button>
                     <button type="button" (click)="back()" class="btn btn-gray btn-default btn-block-mobile">Back</button>
                 </div>
             </form>

--- a/src/app/components/create-group/page-2/create-group-page-2.component.html
+++ b/src/app/components/create-group/page-2/create-group-page-2.component.html
@@ -1,7 +1,7 @@
 <div class="connect-container connect-layout-container">
-    <div class="row">
+    <div class="row soft-top">
         <div class="col-sm-12">
-            <p class="media-meta">STEP 2 OF 9</p>
+            <p class="media-meta flush-bottom">STEP 2 OF 9</p>
             <h3 class="media-heading">Meeting Time</h3>
             <hr>
             <crds-content-block id="groupToolCreateGroupMeetingTimeHelp"></crds-content-block>
@@ -49,7 +49,7 @@
                                 </svg>
                             </span>
                             <div class="border-ends border-sides soft-sides col-sm-12">
-                                 <timepicker [(ngModel)]="createGroupService.group.meetingTime" formControlName="meetingTime" [showMeridian]="true" [minuteStep]="15"></timepicker> 
+                                 <timepicker [(ngModel)]="createGroupService.group.meetingTime" formControlName="meetingTime" [showMeridian]="true" [minuteStep]="15"></timepicker>
                             </div>
                         </div>
                         <div class="soft-top custom-input">
@@ -85,7 +85,8 @@
                     </button>
                     </div>
                 </div>
-                <div class="col-xs-12 btn-block-mobile soft-ends">
+                <div class="col-xs-12">
+                    <hr>
                     <button type="submit" class="btn btn-secondary btn-block-mobile pull-right">Next</button>
                     <button type="button" (click)="back()" class="btn btn-gray btn-default btn-block-mobile">Back</button>
                 </div>

--- a/src/app/components/create-group/page-2/create-group-page-2.component.html
+++ b/src/app/components/create-group/page-2/create-group-page-2.component.html
@@ -1,8 +1,8 @@
 <div class="connect-container connect-layout-container">
     <div class="row soft-top">
-        <div class="col-sm-12">
+        <div class="col-sm-12 soft-top">
             <p class="media-meta flush-bottom">STEP 2 OF 9</p>
-            <h3 class="media-heading">Meeting Time</h3>
+            <h3 class="media-heading font-family-condensed-extra text-uppercase">Meeting Time</h3>
             <hr>
             <crds-content-block id="groupToolCreateGroupMeetingTimeHelp"></crds-content-block>
         </div>
@@ -89,7 +89,7 @@
                 </div>
                 <div class="soft-ends">
                     <hr>
-                    <button type="submit" class="btn btn-secondary btn-block-mobile pull-right">Next</button>
+                    <button type="submit" class="btn btn-primary btn-block-mobile pull-right">Next</button>
                     <button type="button" (click)="onBack()" class="btn btn-gray btn-default btn-block-mobile">Back</button>
                 </div>
             </form>

--- a/src/app/components/create-group/page-2/create-group-page-2.component.html
+++ b/src/app/components/create-group/page-2/create-group-page-2.component.html
@@ -87,7 +87,7 @@
                     </button>
                     </div>
                 </div>
-                <div class="col-xs-12">
+                <div class="soft-ends">
                     <hr>
                     <button type="submit" class="btn btn-secondary btn-block-mobile pull-right">Next</button>
                     <button type="button" (click)="onBack()" class="btn btn-gray btn-default btn-block-mobile">Back</button>

--- a/src/app/components/create-group/page-3/create-group-page-3.component.html
+++ b/src/app/components/create-group/page-3/create-group-page-3.component.html
@@ -1,8 +1,8 @@
 <div class="connect-container connect-layout-container">
     <div class="row soft-top">
-        <div class="col-sm-12">
+        <div class="col-sm-12 soft-top">
             <p class="media-meta flush-bottom">STEP 3 OF 9</p>
-            <h3 class="media-heading">Location</h3>
+            <h3 class="media-heading font-family-condensed-extra text-uppercase">Location</h3>
             <hr>
             <crds-content-block id="groupToolCreateGroupMeetingLocationHelp"></crds-content-block>
         </div>
@@ -157,7 +157,7 @@
                     </div>
 
                     <div class="col-xs-12 btn-block-mobile soft-ends">
-                        <button type="submit" class="btn btn-secondary btn-block-mobile pull-right">Next</button>
+                        <button type="submit" class="btn btn-primary btn-block-mobile pull-right">Next</button>
                         <button type="button" (click)="back()" class="btn btn-gray btn-default btn-block-mobile">Back</button>
                     </div>
                 </div>

--- a/src/app/components/create-group/page-3/create-group-page-3.component.html
+++ b/src/app/components/create-group/page-3/create-group-page-3.component.html
@@ -1,7 +1,7 @@
 <div class="connect-container connect-layout-container">
-    <div class="row">
+    <div class="row soft-top">
         <div class="col-sm-12">
-            <p class="media-meta">STEP 3 OF 9</p>
+            <p class="media-meta flush-bottom">STEP 3 OF 9</p>
             <h3 class="media-heading">Location</h3>
             <hr>
             <crds-content-block id="groupToolCreateGroupMeetingLocationHelp"></crds-content-block>
@@ -69,8 +69,8 @@
                             </div>
 
                             <div class="col-xs-6 hard-right">
-                                <input class="form-control" name="zip" 
-                                       formControlName="zip" placeholder="Zip" 
+                                <input class="form-control" name="zip"
+                                       formControlName="zip" placeholder="Zip"
                                        [(ngModel)]="createGroupService.group.address.zip"
                                        minlength="5" maxlength="5"
                                        type="tel"

--- a/src/app/components/create-group/page-4/create-group-page-4.component.html
+++ b/src/app/components/create-group/page-4/create-group-page-4.component.html
@@ -1,7 +1,7 @@
 <div class="connect-container connect-layout-container">
-    <div class="row">
+    <div class="row soft-top">
         <div class="col-sm-12">
-            <p class="media-meta">STEP 4 OF 9</p>
+            <p class="media-meta flush-bottom">STEP 4 OF 9</p>
             <h3 class="media-heading">Group Type</h3>
             <hr>
             <crds-content-block id="groupToolCreateGroupTypeHelp"></crds-content-block>
@@ -61,7 +61,8 @@
                         This field is required.
                     </div>
                 </div>
-                <div class="col-xs-12 btn-block-mobile soft-ends">
+                <div class="soft-ends">
+                    <hr>
                     <button type="submit" class="btn btn-secondary btn-block-mobile pull-right">Next</button>
                     <button type="button" (click)="back()" class="btn btn-gray btn-default btn-block-mobile">Back</button>
                 </div>

--- a/src/app/components/create-group/page-4/create-group-page-4.component.html
+++ b/src/app/components/create-group/page-4/create-group-page-4.component.html
@@ -1,8 +1,8 @@
 <div class="connect-container connect-layout-container">
     <div class="row soft-top">
-        <div class="col-sm-12">
+        <div class="col-sm-12 soft-top">
             <p class="media-meta flush-bottom">STEP 4 OF 9</p>
-            <h3 class="media-heading">Group Type</h3>
+            <h3 class="media-heading font-family-condensed-extra text-uppercase">Group Type</h3>
             <hr>
             <crds-content-block id="groupToolCreateGroupTypeHelp"></crds-content-block>
         </div>
@@ -63,7 +63,7 @@
                 </div>
                 <div class="soft-ends">
                     <hr>
-                    <button type="submit" class="btn btn-secondary btn-block-mobile pull-right">Next</button>
+                    <button type="submit" class="btn btn-primary btn-block-mobile pull-right">Next</button>
                     <button type="button" (click)="back()" class="btn btn-gray btn-default btn-block-mobile">Back</button>
                 </div>
 

--- a/src/app/components/create-group/page-5/create-group-page-5.component.html
+++ b/src/app/components/create-group/page-5/create-group-page-5.component.html
@@ -1,8 +1,8 @@
 <div class="connect-container connect-layout-container">
     <div class="row soft-top">
-        <div class="col-sm-12">
+        <div class="col-sm-12 soft-top">
             <p class="media-meta flush-bottom">STEP 5 OF 9</p>
-            <h3 class="media-heading">Group Details</h3>
+            <h3 class="media-heading font-family-condensed-extra text-uppercase">Group Details</h3>
             <hr>
             <crds-content-block id="groupToolCreateGroupAboutHelp"></crds-content-block>
         </div>
@@ -71,7 +71,7 @@
 
                 <div class="soft-ends">
                     <hr>
-                    <button type="submit" class="btn btn-secondary btn-block-mobile pull-right">Next</button>
+                    <button type="submit" class="btn btn-primary btn-block-mobile pull-right">Next</button>
                     <button type="button" (click)="back()" class="btn btn-gray btn-default btn-block-mobile">Back</button>
                 </div>
             </form>

--- a/src/app/components/create-group/page-5/create-group-page-5.component.html
+++ b/src/app/components/create-group/page-5/create-group-page-5.component.html
@@ -1,7 +1,7 @@
 <div class="connect-container connect-layout-container">
-    <div class="row">
+    <div class="row soft-top">
         <div class="col-sm-12">
-            <p class="media-meta">STEP 5 OF 9</p>
+            <p class="media-meta flush-bottom">STEP 5 OF 9</p>
             <h3 class="media-heading">Group Details</h3>
             <hr>
             <crds-content-block id="groupToolCreateGroupAboutHelp"></crds-content-block>
@@ -69,7 +69,8 @@
                     </div>
                 </div>
 
-                <div class="col-xs-12 btn-block-mobile soft-ends">
+                <div class="soft-ends">
+                    <hr>
                     <button type="submit" class="btn btn-secondary btn-block-mobile pull-right">Next</button>
                     <button type="button" (click)="back()" class="btn btn-gray btn-default btn-block-mobile">Back</button>
                 </div>


### PR DESCRIPTION
Given a user starting a group by filling out the "start a group" form
When defining the 'group category'
Then I should see fields to select & define attributes associated with one or more categories (Interest, Neighborhood, Spiritual Growth, Life Stages, Healing)

Given a user starting a group by filling out the "start a group" form
When defining the 'meeting time'
Then I should see fields to specify a specific day, time (via time picker) and meeting frequency OR specify that my group's meeting time is 'Flexible / TBD'

Given a user starting a group by filling out the "start a group" form
When defining the 'meeting location'
Then I should see fields to specify 'In Person' (address, city, state, zip & kids) OR 'Online' (TBD)

Given a user starting a group by filling out the "start a group" form
When defining the 'meeting location' as 'In Person'
Then I should see fields to specify whether the 'kids are welcome' at the group

Given a user starting a group by filling out the "start a group" form
When moving through the subsequent screens in the stepped form process
Then I should see fields on the page styled similar to the examples in the DDK.