### PR TITLE
US9159 - Btn Indent Styles

### DIFF
--- a/src/app/components/create-group/page-1/create-group-page-1.component.html
+++ b/src/app/components/create-group/page-1/create-group-page-1.component.html
@@ -23,11 +23,6 @@
 
                     <div *ngIf="category.selected" class="form-group">
                         <div class="input-group input-group-block input-group-left custom-input">
-                            <span class="custom-input-icon">
-                                <svg class="icon icon-1" viewBox="0 0 256 256">
-                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#chevron-right"></use>
-                                </svg>
-                            </span>
                             <input type="text" class="form-control" placeholder="{{category.exampleText}}" id="{{category.name}}-detail" maxlength="25"
                                 value="{{category.categoryDetail}}" formControlName="{{category.name}}-detail" [(ngModel)]="category.categoryDetail"
                                 required>

--- a/src/app/components/create-group/page-2/create-group-page-2.component.html
+++ b/src/app/components/create-group/page-2/create-group-page-2.component.html
@@ -16,75 +16,60 @@
                             [ngClass]="{active: createGroupService.meetingTimeType === groupMeetingScheduleType.SPECIFIC_TIME_AND_DATE}"
                         formControlName="meetingTimeType" value="specific"
                         (click)="onClick(groupMeetingScheduleType.SPECIFIC_TIME_AND_DATE)" ngDefaultControl>
-                    <div class="btn-group-label text-left row">
-                        <span class="btn-group-icons">
-                            <svg class="icon circle-thin" viewBox="0 0 256 256">
-                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#circle-thin" height="256" width="256"></use>
-                            </svg>
-                            <svg class="icon check-circle" viewBox="0 0 256 256">
-                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#check-circle" height="256" width="256"></use>
-                            </svg>
-                        </span>
-                        Specific Day and Time
-                    </div>
+                        <div class="btn-group-label text-left row">
+                            <span class="btn-group-icons">
+                                <svg class="icon circle-thin" viewBox="0 0 256 256">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#circle-thin" height="256" width="256"></use>
+                                </svg>
+                                <svg class="icon check-circle" viewBox="0 0 256 256">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#check-circle" height="256" width="256"></use>
+                                </svg>
+                            </span>
+                            Specific Day and Time
+                        </div>
                     </button>
 
                     <div *ngIf="createGroupService.meetingTimeType === groupMeetingScheduleType.SPECIFIC_TIME_AND_DATE">
-                        <div class="soft-top custom-input">
-                            <span class="custom-input-icon">
-                                <svg class="icon icon-1" viewBox="0 0 256 256">
-                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#chevron-right"></use>
-                                </svg>
-                            </span>
+                        <div class="push-top custom-input">
                             <select class="form-control" name="meetingDay" [(ngModel)]="createGroupService.group.meetingDayId" formControlName="meetingDay"  (change)="onDayChange($event.target.value)">
-                            <option value="null" disabled="true" [selected]="!createGroupService.group.meetingDayId">Select a day..</option>
-                            <option *ngFor="let day of daysOfTheWeek" [value]="day.dp_RecordID">{{day.dp_RecordName}}</option>
-                        </select>
-                        </div>
-                        <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || meetingTimeForm.controls['meetingDay'].valid">
-                            <crds-content-block id="oneOptionMustBeSelected"></crds-content-block>
-                        </div>
-                        <div class="soft-top custom-input">
-                            <span class="custom-input-icon">
-                                <svg class="icon icon-1" viewBox="0 0 256 256">
-                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#chevron-right"></use>
-                                </svg>
-                            </span>
-                            <div class="border-ends border-sides soft-sides col-sm-12">
-                                 <timepicker [(ngModel)]="createGroupService.group.meetingTime" formControlName="meetingTime" [showMeridian]="true" [minuteStep]="15"></timepicker>
+                                <option value="null" disabled="true" [selected]="!createGroupService.group.meetingDayId">Select a day..</option>
+                                <option *ngFor="let day of daysOfTheWeek" [value]="day.dp_RecordID">{{day.dp_RecordName}}</option>
+                            </select>
+                            <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || meetingTimeForm.controls['meetingDay'].valid">
+                                <crds-content-block id="oneOptionMustBeSelected"></crds-content-block>
                             </div>
-                        </div>
-                        <div class="soft-top custom-input">
-                            <span class="custom-input-icon">
-                                <svg class="icon icon-1" viewBox="0 0 256 256">
-                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#chevron-right"></use>
-                                </svg>
-                            </span>
-                            <select class="form-control" name="meetingFrequency" [(ngModel)]="createGroupService.group.meetingFrequencyId" formControlName="meetingFrequency" (change)="onFrequencyChange($event.target.value)">
-                            <option value="null" disabled="true" [selected]="!createGroupService.group.meetingFrequencyId">Select a frequency</option>
-                            <option *ngFor="let frequency of meetingFrequencies" [value]="frequency.meetingFrequencyId">{{frequency.meetingFrequencyDesc}}</option>
-                        </select>
-                        </div>
-                        <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || meetingTimeForm.controls['meetingFrequency'].valid">
-                            <crds-content-block id="oneOptionMustBeSelected"></crds-content-block>
+                            <div class="soft-top">
+                                <div class="border-ends border-sides soft-sides">
+                                    <timepicker [(ngModel)]="createGroupService.group.meetingTime" formControlName="meetingTime" [showMeridian]="true" [minuteStep]="15"></timepicker>
+                                </div>
+                            </div>
+                            <div class="soft-top">
+                                <select class="form-control" name="meetingFrequency" [(ngModel)]="createGroupService.group.meetingFrequencyId" formControlName="meetingFrequency" (change)="onFrequencyChange($event.target.value)">
+                                    <option value="null" disabled="true" [selected]="!createGroupService.group.meetingFrequencyId">Select a frequency</option>
+                                    <option *ngFor="let frequency of meetingFrequencies" [value]="frequency.meetingFrequencyId">{{frequency.meetingFrequencyDesc}}</option>
+                                </select>
+                            </div>
+                            <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || meetingTimeForm.controls['meetingFrequency'].valid">
+                                <crds-content-block id="oneOptionMustBeSelected"></crds-content-block>
+                            </div>
                         </div>
                     </div>
 
-                    <div class="btn-group btn-group-block soft-top">
+                    <div class="push-top btn-group-block">
                         <button type="button" class="btn btn-option btn-flex btn-outline" id="flexible" [ngClass]="{active: createGroupService.meetingTimeType === groupMeetingScheduleType.FLEXIBLE}"
-                            formControlName="meetingTimeType" value="flexible" (click)="onClick(groupMeetingScheduleType.FLEXIBLE)" ngDefaultControl>
-                        <div class="btn-group-label text-left row">
-                        <span class="btn-group-icons">
-                            <svg class="icon circle-thin" viewBox="0 0 256 256">
-                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#circle-thin" height="256" width="256"></use>
-                            </svg>
-                            <svg class="icon check-circle" viewBox="0 0 256 256">
-                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#check-circle" height="256" width="256"></use>
-                            </svg>
-                        </span>
-                        Flexible Meeting Time/Not Sure Yet
-                    </div>
-                    </button>
+                                formControlName="meetingTimeType" value="flexible" (click)="onClick(groupMeetingScheduleType.FLEXIBLE)" ngDefaultControl>
+                            <div class="btn-group-label text-left row">
+                                <span class="btn-group-icons">
+                                    <svg class="icon circle-thin" viewBox="0 0 256 256">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#circle-thin" height="256" width="256"></use>
+                                    </svg>
+                                    <svg class="icon check-circle" viewBox="0 0 256 256">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#check-circle" height="256" width="256"></use>
+                                    </svg>
+                                </span>
+                                Flexible Meeting Time/Not Sure Yet
+                            </div>
+                        </button>
                     </div>
                 </div>
                 <div class="soft-ends">

--- a/src/app/components/create-group/page-3/create-group-page-3.component.html
+++ b/src/app/components/create-group/page-3/create-group-page-3.component.html
@@ -11,96 +11,63 @@
         <div class="col-sm-12">
             <p class="control-label soft-top">Where will your group meet?</p>
             <form [formGroup]="locationForm" (ngSubmit)="onSubmit(locationForm)">
-                <div class="btn-group btn-group-block">
+                <div class="btn-group-block">
                     <button type="button" class="btn btn-option btn-flex btn-outline" id="specific" [ngClass]="{active: !createGroupService.group.isVirtualGroup}"
                         formControlName="isVirtualGroup" value="false" (click)="onClickIsVirtual(false)" ngDefaultControl>
-                    <div class="btn-group-label text-left row">
-                        <span class="btn-group-icons">
-                            <svg class="icon circle-thin" viewBox="0 0 256 256">
-                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#circle-thin" height="256" width="256"></use>
-                            </svg>
-                            <svg class="icon check-circle" viewBox="0 0 256 256">
-                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#check-circle" height="256" width="256"></use>
-                            </svg>
-                        </span>
-                        In Person
-                    </div>
-                    </button>
-
-                    <div *ngIf="!createGroupService.group.isVirtualGroup">
-                        <div class="soft-top custom-input">
-                            <span class="custom-input-icon">
-                                <svg class="icon icon-1" viewBox="0 0 256 256">
-                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#chevron-right"></use>
+                        <div class="btn-group-label text-left row">
+                            <span class="btn-group-icons">
+                                <svg class="icon circle-thin" viewBox="0 0 256 256">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#circle-thin" height="256" width="256"></use>
+                                </svg>
+                                <svg class="icon check-circle" viewBox="0 0 256 256">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#check-circle" height="256" width="256"></use>
                                 </svg>
                             </span>
-                            <input class="form-control" name="address" formControlName="address" placeholder="Address" [(ngModel)]="createGroupService.group.address.addressLine1">
+                            In Person
                         </div>
+                    </button>
+
+                    <div class="custom-input push-top" *ngIf="!createGroupService.group.isVirtualGroup">
+                        <input class="form-control" name="address" formControlName="address" placeholder="Address" [(ngModel)]="createGroupService.group.address.addressLine1">
                         <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || locationForm.controls['address'].valid">
                             <p>Address is required</p>
                         </div>
-
-                        <div class="soft-top custom-input">
-                            <span class="custom-input-icon">
-                                <svg class="icon icon-1" viewBox="0 0 256 256">
-                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#chevron-right"></use>
-                                </svg>
-                            </span>
-                            <input class="form-control" name="city" formControlName="city" placeholder="City" [(ngModel)]="createGroupService.group.address.city">
-                        </div>
+                        <input class="push-top form-control" name="city" formControlName="city" placeholder="City" [(ngModel)]="createGroupService.group.address.city">
                         <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || locationForm.controls['city'].valid">
                             <p>City is required</p>
                         </div>
-                        <div class="soft-top custom-input">
-                            <span class="custom-input-icon">
-                                <svg class="icon icon-1" viewBox="0 0 256 256">
-                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#chevron-right"></use>
-                                </svg>
-                            </span>
-                            <div class="col-xs-6 hard-left soft-right">
-                                <select class="form-control" name="state" formControlName="state" placeholder="State" [(ngModel)]="createGroupService.group.address.state">
-                                <option value="null" disabled="true" [selected]="!createGroupService.group.address.state">State</option>
-                                <option *ngFor="let state of usStatesList" [value]="state">{{state}}</option>
-                            </select>
-
-                                <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || locationForm.controls['state'].valid">
-                                    <crds-content-block id="oneOptionMustBeSelected"></crds-content-block>
+                        <div>
+                            <div class="push-top row">
+                                <div class="col-xs-6 hard-left soft-right">
+                                    <select class="form-control" name="state" formControlName="state" placeholder="State" [(ngModel)]="createGroupService.group.address.state">
+                                        <option value="null" disabled="true" [selected]="!createGroupService.group.address.state">State</option>
+                                        <option *ngFor="let state of usStatesList" [value]="state">{{state}}</option>
+                                    </select>
+                                    <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || locationForm.controls['state'].valid">
+                                        <crds-content-block id="oneOptionMustBeSelected"></crds-content-block>
+                                    </div>
                                 </div>
-                            </div>
-
-                            <div class="col-xs-6 hard-right">
-                                <input class="form-control" name="zip"
-                                       formControlName="zip" placeholder="Zip"
-                                       [(ngModel)]="createGroupService.group.address.zip"
-                                       minlength="5" maxlength="5"
-                                       type="tel"
-                                       onlyTheseKeys="[0-9]">
-
-                                <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || locationForm.controls['zip'].valid">
-                                    <crds-content-block id="invalidZip"></crds-content-block>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-xs-12">
-                                <div class="pull-left">
-                                    <div class="custom-input">
-                                        <span class="custom-input-icon">
-                                <svg class="icon icon-1" viewBox="0 0 256 256">
-                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#chevron-right"></use>
-                                </svg>
-                            </span>
-                                        <label class="control-label custom-input-icon">Are kids welcome at the group?</label>
+                                <div class="col-xs-6 hard-right">
+                                    <input class="form-control" name="zip"
+                                            formControlName="zip" placeholder="Zip"
+                                            [(ngModel)]="createGroupService.group.address.zip"
+                                            minlength="5" maxlength="5"
+                                            type="tel"
+                                            onlyTheseKeys="[0-9]">
+                                    <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || locationForm.controls['zip'].valid">
+                                        <crds-content-block id="invalidZip"></crds-content-block>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                        <div class="col-sm-12 hard-right">
-                            <div class="push-left btn-group btn-group-block">
-                                <button type="button" class="btn btn-option btn-flex btn-outline" id="specific" [ngClass]="{active: createGroupService.group.kidsWelcome}"
-                                    formControlName="kidsWelcome" value="true" (click)="onClickKidsWelcome(true)" ngDefaultControl
-                                    style="white-space: normal">
-                                    <div class="btn-group-label text-left row">
+                        <div class="push-top">
+                            <label class="control-label">Are kids welcome at the group?</label>
+                        </div>
+                        <div class="btn-group-block">
+                            <button type="button" class="btn btn-option btn-flex btn-outline" id="specific" [ngClass]="{active: createGroupService.group.kidsWelcome}"
+                                formControlName="kidsWelcome" value="true" (click)="onClickKidsWelcome(true)" ngDefaultControl
+                                style="white-space: normal">
+                                <div class="btn-group-label text-left row">
                                     <span class="btn-group-icons">
                                         <svg class="icon circle-thin" viewBox="0 0 256 256">
                                             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#circle-thin" height="256" width="256"></use>
@@ -109,16 +76,32 @@
                                             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#check-circle" height="256" width="256"></use>
                                         </svg>
                                     </span>
-                                        Yep. Kids are welcome. As a group, we'll decide what to do with them.
-                                    </div>
-                                </button>
+                                    Yep. Kids are welcome. As a group, we'll decide what to do with them.
+                                </div>
+                            </button>
+                            <button type="button" class="btn btn-option btn-flex btn-outline" id="specific" [ngClass]="{active: createGroupService.group.kidsWelcome === false}"
+                                formControlName="kidsWelcome" value="false" (click)="onClickKidsWelcome(false)" ngDefaultControl>
+                                <div class="btn-group-label text-left row">
+                                    <span class="btn-group-icons">
+                                        <svg class="icon circle-thin" viewBox="0 0 256 256">
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#circle-thin" height="256" width="256"></use>
+                                        </svg>
+                                        <svg class="icon check-circle" viewBox="0 0 256 256">
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#check-circle" height="256" width="256"></use>
+                                        </svg>
+                                    </span>
+                                    No. Adults only please.
+                                </div>
+                            </button>
+                            <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || locationForm.controls['kidsWelcome'].valid">
+                                <crds-content-block id="oneOptionMustBeSelected"></crds-content-block>
                             </div>
                         </div>
+                    </div>
 
-                        <div class="col-sm-12 hard-right">
-                            <div class="push-left btn-group btn-group-block">
-                                <button type="button" class="btn btn-option btn-flex btn-outline" id="specific" [ngClass]="{active: createGroupService.group.kidsWelcome === false}"
-                                    formControlName="kidsWelcome" value="false" (click)="onClickKidsWelcome(false)" ngDefaultControl>
+                    <div class="btn-group btn-group-block soft-top">
+                        <button type="button" class="btn btn-option btn-flex btn-outline" id="online" [ngClass]="{active: createGroupService.group.isVirtualGroup}"
+                            formControlName="isVirtualGroup" value="true" (click)="onClickIsVirtual(true)" ngDefaultControl>
                             <div class="btn-group-label text-left row">
                                 <span class="btn-group-icons">
                                     <svg class="icon circle-thin" viewBox="0 0 256 256">
@@ -128,32 +111,9 @@
                                         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#check-circle" height="256" width="256"></use>
                                     </svg>
                                 </span>
-                                No. Adults only please.
+                                Online
                             </div>
-                            </button>
-                            </div>
-                            <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || locationForm.controls['kidsWelcome'].valid">
-                                    <crds-content-block id="oneOptionMustBeSelected"></crds-content-block>
-                                </div>
-                        </div>
-
-                    </div>
-
-                    <div class="btn-group btn-group-block soft-top">
-                        <button type="button" class="btn btn-option btn-flex btn-outline" id="online" [ngClass]="{active: createGroupService.group.isVirtualGroup}"
-                            formControlName="isVirtualGroup" value="true" (click)="onClickIsVirtual(true)" ngDefaultControl>
-                        <div class="btn-group-label text-left row">
-                        <span class="btn-group-icons">
-                            <svg class="icon circle-thin" viewBox="0 0 256 256">
-                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#circle-thin" height="256" width="256"></use>
-                            </svg>
-                            <svg class="icon check-circle" viewBox="0 0 256 256">
-                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#check-circle" height="256" width="256"></use>
-                            </svg>
-                        </span>
-                        Online
-                    </div>
-                    </button>
+                        </button>
                     </div>
 
                     <div class="soft-ends">


### PR DESCRIPTION
Given a designer/developer 
When implementing a btn form group on a Crds application
Then I should find implementation details for the updated btn group in the DDK with the vertical rule for indented/child options rather than the caret

Given a crds.net/groups user
When starting a group
Then I should see the updated btn form group implemented within any selections that have nested child options 

---

Corresponds to crdschurch/crds-styleguide#189 and crdschurch/crds-styles#173.