### PR TITLE
DE3968 - Accept/deny buttons

### DIFF
--- a/src/app/components/pin-details/gathering/gathering-requests/gathering-requests.html
+++ b/src/app/components/pin-details/gathering/gathering-requests/gathering-requests.html
@@ -13,9 +13,9 @@
       <div class="pending-requests push-half-bottom">
         <p class="text-muted font-size-smaller">Requested to join on {{ inquiry.requestDate | date:"MM/dd/yyyy" }}</p>
 
-        <div class="btn-group btn-block-mobile clearfix">
-          <button class="btn btn-primary btn-block-mobile" (click)="acceptOrDenyInquiry(inquiry, true)">Accept</button>
-          <button class="btn btn-default btn-outline btn-block-mobile" (click)="acceptOrDenyInquiry(inquiry, false)">Deny</button>
+        <div class="btn-group">
+          <button class="btn btn-primary" (click)="acceptOrDenyInquiry(inquiry, true)">Accept</button>
+          <button class="btn btn-default btn-outline" (click)="acceptOrDenyInquiry(inquiry, false)">Deny</button>
         </div>
 
         <div *ngIf="inquiry.error" class="error help-block">


### PR DESCRIPTION
Change participant request buttons from full-width on mobile to side-by-side.
No corresponding PRs.

---
Steps to reproduce
One mobile screen
-go to /connect
-click My Stuff
-log in (tester21@gmail.com, password=password)
-click list toggle
-Click into host

Actual result = buttons are wide and stacked on top of each other

Expect result = buttons should be side by side