### PR TITLE
US9342 - Social icons

### DIFF
--- a/src/app/components/pin-details/gathering/gathering.html
+++ b/src/app/components/pin-details/gathering/gathering.html
@@ -25,7 +25,7 @@
         {{descriptionToDisplay}}
         <a *ngIf="!doDisplayFullDesc" (click)="expandGroupDescription()" class="pointer">More</a>
 
-        <!-- <span *ngIf="doDisplayFullDesc">
+        <span>
           <ul class="list-inline push-top">
             <li>
               <a href="#">
@@ -42,8 +42,16 @@
                 </svg>
               </a>
             </li>
+
+            <li>
+              <a href="#">
+                <svg class="icon icon-2" viewBox="0 0 256 256">
+                  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#link"></use>
+                </svg>
+              </a>
+            </li>
           </ul>
-        </span> -->
+        </span>
       </p>
 
       <!--below we are hiding the edit button for groups detail page because that story is not finished.-->


### PR DESCRIPTION
Add link icon to pin details and make visible at all times.

Modify the group detail view such that the social icons appear outside of the expanded description field. User should not have to expand description to access the social icons to share the group. Defer to Rob for positioning as needed. 

Also we need to add a link icon so the user can copy the direct URL to the group.

Corresponds with crdschurch/crds-styles#180
Corresponds with crdschurch/crds-styleguide#192