### PR TITLE
Address Form's Zip Code field now accepts long format (i.e. #####-####)

### DIFF
--- a/src/app/components/address-form/address-form.component.html
+++ b/src/app/components/address-form/address-form.component.html
@@ -67,7 +67,7 @@
     <div class="form-group col-xs-6" [formGroupName]="groupName">
       <label class="sr-only" for="zip">Zip Code</label>
       <input type="tel"
-             onlyTheseKeys="[0-9]"
+             onlyTheseKeys="[0-9\-]"
              class="form-control"
              maxlength="10"
              placeholder="Zip Code"
@@ -79,5 +79,7 @@
 
       <p [class]="errorClasses" *ngIf= "isFormSubmitted && !addressFormGroup.controls['zip'].valid">Zip is required!</p>
     </div>
+
+
   </div>
 </form>


### PR DESCRIPTION
https://rally1.rallydev.com/#/66097202244d/detail/defect/140576807632