### PR TITLE
DE4000 - Filter takeover

### DIFF
--- a/src/app/components/neighbors/neighbors.component.html
+++ b/src/app/components/neighbors/neighbors.component.html
@@ -3,6 +3,8 @@
                 (viewMap)="viewChanged($event)">
 </app-search-bar>
 
-<app-map [searchResults]="pinSearchResults" *ngIf="mapViewActive && !isMapHidden"></app-map>
+<div *ngIf="!this.state.getIsFilteredDialogOpen()">
+  <app-map [searchResults]="pinSearchResults" *ngIf="mapViewActive && !isMapHidden"></app-map>
 
-<app-listview [searchResults]="pinSearchResults" *ngIf="!mapViewActive"></app-listview>
+  <app-listview [searchResults]="pinSearchResults" *ngIf="!mapViewActive"></app-listview>
+</div>


### PR DESCRIPTION
Hide map/list if search filter is visible.

No other PRs.

---
Finder Groups filter, when expanded, should cover entire view behind it. Currently the layer below is visible at the bottom of the map. 