### PR TITLE
US9306 - Contact fauxdal

### DIFF
--- a/src/app/components/contact-leader/contact-leader.component.ts
+++ b/src/app/components/contact-leader/contact-leader.component.ts
@@ -17,7 +17,8 @@ import { MsgToLeader } from '../../models/msg-to-leader';
 
 @Component({
     selector: 'contact-leader',
-    templateUrl: 'contact-leader.component.html'
+    templateUrl: 'contact-leader.component.html',
+    styles: ['.fauxdal-wrapper { overflow-y: auto; }']
 })
 export class ContactLeaderComponent implements OnInit, AfterViewInit {
 


### PR DESCRIPTION
Remove the scrollbar from the contact leader form. This fixes the margin spacing to the right of the content so it looks good on mobile.

This has no corresponding PRs.