### PR TITLE
US9346 - Container Padding Top

### DIFF
--- a/src/app/components/getting-started/getting-started.component.html
+++ b/src/app/components/getting-started/getting-started.component.html
@@ -38,7 +38,7 @@
     </div>
 
     <!-- Be a Leader Text/Buttons -->
-    <crds-content-block id="finderGettingStartedGroupsLeader"></crds-content-block>                            
+    <crds-content-block id="finderGettingStartedGroupsLeader"></crds-content-block>
 
     <div class="push-bottom soft-bottom">
       <div class="btn-group full-width">
@@ -47,16 +47,16 @@
       </div>
     </div>
     <!-- Onsite Group info -->
-    <crds-content-block id="finderGettingStartedGroupsOnSite"></crds-content-block>  
+    <crds-content-block id="finderGettingStartedGroupsOnSite"></crds-content-block>
 
     <div class="soft-bottom soft-quarter-top">
       <div class="btn-group full-width">
         <a (click)="onClickOnsiteGroups()"  class="btn btn-primary btn-block-mobile">Onsite groups</a>
       </div>
-    </div>  
+    </div>
 
     <!-- Faqs -->
     <crds-content-block id="finderGettingStartedGroupsFaqs"></crds-content-block>
-  </div>  
-  
+  </div>
+
 </div>

--- a/src/styles/application.scss
+++ b/src/styles/application.scss
@@ -70,6 +70,7 @@ app-neighbors {
 .connect-container {
   background: $cr-white;
   min-height: 381px;
+  overflow: hidden;
 
   @for $idx from 5 to 30 {
     $height: $idx * 100;


### PR DESCRIPTION
Given a CMS user
When authoring content in the CMS that should live within the Connect application containers
Then I should be able to lead with an H tag without creating a gap at the top of the connect container. 

---

See more about the tabs here: https://stackoverflow.com/a/2890369/2241124

---

No other corresponding PRs.