### PR TITLE
DE4044 - Create group btns text explosion

### DIFF
--- a/src/app/components/create-group/page-2/create-group-page-2.component.ts
+++ b/src/app/components/create-group/page-2/create-group-page-2.component.ts
@@ -18,6 +18,17 @@ import { defaultGroupMeetingTime, meetingFrequencies,
 @Component({
   selector: 'create-group-page-2',
   templateUrl: './create-group-page-2.component.html',
+  styles: [`
+    form > div:nth-child(2) .row div:last-child {
+      white-space: normal;
+      text-align: left;
+    }
+    @media (min-width: 600px) {
+      form > div:nth-child(2) .row div:last-child {
+        text-align: right;
+      }
+    }
+  `]
 })
 export class CreateGroupPage2Component implements OnInit {
   public meetingTimeForm: FormGroup;


### PR DESCRIPTION
Add style override for button text overflow.

No corresponding PRs.

---
**Modify this short term such that the labels are cleaned up and don't flow off the btn on smaller device widths. The longer term solution will be governed by a story that incorporates Rob's adjusted design and approach for how to utilize these buttons.
-BB

Back next buttons do not match design, also the Right-text on the option button is cut off (see attached screenshot for both issues)