### PR TITLE
DE4077 - Active Filter Button

### DIFF
--- a/src/app/components/filters/filters.component.ts
+++ b/src/app/components/filters/filters.component.ts
@@ -87,11 +87,12 @@ export class FiltersComponent implements OnInit {
     this.onlineOrPhysicalGroupComponent.reset();
     this.filterService.resetFilterString();
     this.state.setIsFilterDialogOpen(false);
-    this.onSubmit();
+    this.onSubmit(false);
   }
 
-  public onSubmit(): void {
+  public onSubmit(filterActive = true): void {
     this.location = this.locationFormGroup.controls.location.value;
+    this.state.isFilterActive = filterActive;
     this.applyFilters();
   }
 

--- a/src/app/components/search-bar/search-bar.component.html
+++ b/src/app/components/search-bar/search-bar.component.html
@@ -22,7 +22,7 @@
         </span>
 
         <span class="addon-btn" *ngIf="appSettings.isSmallGroupApp()">
-          <button type="button" role="button" (click)="toggleFilters()" [class.open]="state.isFilterDialogOpen">
+          <button type="button" role="button" (click)="toggleFilters()" [class.open]="state.isFilterDialogOpen" [class.active]="state.isFilterActive">
             <svg class="icon icon-1" viewBox="0 0 256 256">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#equalizer"></use>
             </svg>

--- a/src/app/components/search-bar/search-bar.component.scss
+++ b/src/app/components/search-bar/search-bar.component.scss
@@ -1,3 +1,5 @@
+@import '~crds-styles/assets/stylesheets/variables';
+
 ::-ms-clear {
     display: none;
 }
@@ -19,4 +21,8 @@
   @media (min-width: 1200px) {
     width: 750px;
   }
+}
+
+.searchbar .addon-btn button.active {
+  color: $cr-teal;
 }

--- a/src/app/services/state.service.ts
+++ b/src/app/services/state.service.ts
@@ -24,6 +24,7 @@ export class StateService {
   public hasPageHeader: boolean = false;
   public is_loading: boolean = false;
   public isFilterDialogOpen: boolean = false;
+  public isFilterActive: boolean = false;
   public lastSearch: SearchOptions;
   private lastSearchResults: PinSearchResultsDto;
   public myStuffActive: boolean = false;


### PR DESCRIPTION
Current behavior:
When filters are applied, equalizer icon does not change color to reflect the enabled state.


Expected behavior:
When returned to map/list page, the equalizer icon in the search bar should display an enabled state. Use $cr-teal for this. 

---

crdschurch/crds-styles#201