### PR TITLE
DE4139

### DIFF
--- a/src/app/components/create-group/page-2/create-group-page-2.component.ts
+++ b/src/app/components/create-group/page-2/create-group-page-2.component.ts
@@ -10,6 +10,7 @@ import { LookupService } from '../../../services/lookup.service';
 import { StateService } from '../../../services/state.service';
 import { TimeHelperService} from '../../../services/time-helper.service';
 
+import { Group } from '../../../models/group';
 import { LookupTable } from '../../../models';
 
 import { defaultGroupMeetingTime, meetingFrequencies,
@@ -110,7 +111,11 @@ export class CreateGroupPage2Component implements OnInit {
     this.state.setLoading(true);
     this.isSubmitted = true;
     if (form.valid) {
-      this.groupService.navigateInGroupFlow(GroupPageNumber.THREE, this.state.getActiveGroupPath(), this.createGroupService.group.groupId);
+      if(this.createGroupService.meetingTimeType === groupMeetingScheduleType.FLEXIBLE){
+        this.createGroupService.group = this.clearGroupMeetingDay(this.createGroupService.group);
+      }
+      this.groupService.navigateInGroupFlow(GroupPageNumber.THREE, this.state.getActiveGroupPath(),
+                                            this.createGroupService.group.groupId);
     } else {
       this.state.setLoading(false);
     }
@@ -192,6 +197,13 @@ export class CreateGroupPage2Component implements OnInit {
       this.createGroupService.group.meetingDay = daysOfWeekList[this.createGroupService.groupBeingEdited.meetingDayId - 1];
       this.createGroupService.group.meetingDayId = this.createGroupService.groupBeingEdited.meetingDayId;
     }
+  }
+
+  private clearGroupMeetingDay(group: Group): Group {
+    group.meetingDay = null;
+    group.meetingDayId = null;
+
+    return group;
   }
 
 }


### PR DESCRIPTION
Group preview does not show "Flexible Meeting Time" when user toggles to it. This was due to meeting day not being cleared - we use null meeting day as an indicator of a flexible meeting time. Cleared it, verified that group is not being saved with meetingTime, etc fields if flexible meeting time is selected.