### PR TITLE
add editorconfig and 2 spaces to tslint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -32,3 +32,12 @@ An example `http://localhost:8080?theme=light`
 ## Apache configuration
 
 For additional apache configurations, please modify the `apache_site.conf` file in the root of this repository.
+
+## Editor Config
+
+This repo uses an [Editor Config](http://editorconfig.org/) to enforce some code sytles, know that some editors require a plugin to utilize this functionality. 
+- [VSCode](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
+- [Atom](https://github.com/sindresorhus/atom-editorconfig#readme)
+- [Emacs](https://github.com/editorconfig/editorconfig-emacs#readme)
+
+It is your responsibility as a developer of this project to make sure your editor reads this configuration and enforces it. 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "css-to-string-loader": "0.1.2",
     "del-cli": "^0.2.1",
     "dotenv-webpack": "1.4.0",
+    "editorconfig": "^0.14.1",
     "extract-text-webpack-plugin": "2.1.0",
     "file-loader": "0.9.0",
     "html-loader": "0.4.4",

--- a/tslint.json
+++ b/tslint.json
@@ -13,7 +13,8 @@
     "forin": true,
     "indent": [
       true,
-      "spaces"
+      "spaces",
+      2
     ],
     "label-position": true,
     "max-line-length": [


### PR DESCRIPTION
[Editor Config](http://editorconfig.org/)
This will add rules and enforce the spacing for our typescript / js files in the connect repository. This works out of the box for some editors (IntelliJ). Other editors require the user to install a plugin for the enforcement to occur. 

- [VSCode](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
- [Atom](https://github.com/sindresorhus/atom-editorconfig#readme)
- [Emacs](https://github.com/editorconfig/editorconfig-emacs#readme)

This change will require an npm i