### PR TITLE
Single quotes in search string are now URL encoded to %27

### DIFF
--- a/src/app/components/search-bar/search-bar.component.spec.ts
+++ b/src/app/components/search-bar/search-bar.component.spec.ts
@@ -90,10 +90,10 @@ describe('SearchBarComponent', () => {
     expect(mockStateService.setMyViewOrWorldView).toHaveBeenCalledWith('world');
   });
 
-  it('should ignore apostrophes in search string', () => {
+  it('should escape apostrophes in search string', () => {
     <jasmine.Spy>(mockAppSettingsService.isConnectApp).and.returnValue(true);
     comp.ngOnInit();
-    const filteredPinSearch = new PinSearchRequestParams('Phils cool group!', null, undefined);
+    const filteredPinSearch = new PinSearchRequestParams('Phil%27s cool group!', null, undefined);
     mockPinService.emitPinSearchRequest.and.returnValue(true);
 
     comp.onSearch('Phil\'s cool group!');

--- a/src/app/components/search-bar/search-bar.component.ts
+++ b/src/app/components/search-bar/search-bar.component.ts
@@ -65,11 +65,9 @@ export class SearchBarComponent implements OnChanges, OnInit {
     this.state.myStuffActive = false;
     this.state.setMyViewOrWorldView('world');
     this.state.setIsFilterDialogOpen(false);
-
-    // Remove apostrophes from search string:
-    search = search.split('')
-    .filter((letter) => letter !== '\'')
-    .join('');
+    this.state.searchBarText = search;
+    
+    search = search.replace(/'/g, '%27');  // Escape single quotes in the search string
 
     // This needs to go away soon -- you can have location filter and keyword search in connect.
     let locationFilter = this.appSettings.isConnectApp() ? search : null;
@@ -78,7 +76,6 @@ export class SearchBarComponent implements OnChanges, OnInit {
 
     let pinSearchRequest = new PinSearchRequestParams(locationFilter, keywordString, filterString);
     this.state.lastSearch.search = search;
-    this.state.searchBarText = search;
     this.pinService.emitPinSearchRequest(pinSearchRequest);
   }
 


### PR DESCRIPTION
https://rally1.rallydev.com/#/66097202244d/detail/defect/146571902544