### PR TITLE
DE4157

### DIFF
--- a/src/app/components/pin-details/gathering/gathering.html
+++ b/src/app/components/pin-details/gathering/gathering.html
@@ -82,7 +82,7 @@
     <hr class="push-quarter-top flush-bottom">
     <div *ngFor="let participant of pin.gathering.Participants">
       <div class="border-bottom">
-        <participant-card [participant]="participant" [pinParticipantId]="pin.participantId"></participant-card>
+        <participant-card [participant]="participant" [pinParticipantId]="pin.participantId" [groupCardIsDisplayedOn]="pin.gathering"></participant-card>
       </div>
     </div>
     <email-participants [participantEmails]="participantEmails"></email-participants>

--- a/src/app/components/pin-details/gathering/participant-card/participant-card.component.spec.ts
+++ b/src/app/components/pin-details/gathering/participant-card/participant-card.component.spec.ts
@@ -11,6 +11,8 @@ import { AppSettingsService } from '../../../../services/app-settings.service';
 import { SessionService } from '../../../../services/session.service';
 import { ParticipantCardComponent } from './participant-card.component';
 import { MockComponent } from '../../../../shared/mock.component';
+
+import { Group } from '../../../../models/group';
 import { Participant } from '../../../../models/participant';
 
 class ActivatedRouteStub {
@@ -103,7 +105,19 @@ describe('ParticipantCardComponent', () => {
     expect(comp.showLeaderLabel()).toBe(false);
   });
 
-  it('should navigate on card click', () => {
+  it('should navigate appropriately on card click in group tool', () => {
+    comp.pinParticipantId = 777;
+    comp.participant.participantId = 777;
+    comp.participant.groupParticipantId = 777;
+    comp['participant'].canBeHyperlinked = true;
+    comp['groupCardIsDisplayedOn'] = Group.overload_Constructor_CreateGroup(123);
+    mockAppSettings.isSmallGroupApp.and.returnValue(true);
+    comp.onParticipantClick();
+    let route: string = `/small-group/0/participant-detail/777`;
+    expect(mockRouter.navigate).toHaveBeenCalledWith([route]);
+  });
+
+  it('should navigate appropriately on card click in connect', () => {
     comp.pinParticipantId = 777;
     comp.participant.participantId = 777;
     comp.participant.groupParticipantId = 777;

--- a/src/app/components/pin-details/gathering/participant-card/participant-card.component.ts
+++ b/src/app/components/pin-details/gathering/participant-card/participant-card.component.ts
@@ -3,7 +3,10 @@ import { Component, OnInit, Input } from '@angular/core';
 
 import { SessionService } from '../../../../services/session.service';
 import { AppSettingsService } from '../../../../services/app-settings.service';
+
+import { Group } from '../../../../models/group';
 import { Participant } from '../../../../models/participant';
+
 import { GroupRole } from '../../../../shared/constants';
 
 @Component({
@@ -14,6 +17,7 @@ export class ParticipantCardComponent implements OnInit {
 
   @Input() participant: Participant;
   @Input() pinParticipantId: number;
+  @Input() groupCardIsDisplayedOn: Group;
   public isLeader: boolean = false;
   public isMe: boolean = false;
   public isApprentice: boolean = false;
@@ -51,7 +55,9 @@ export class ParticipantCardComponent implements OnInit {
 
   public onParticipantClick(): void {
       if (this.participant.canBeHyperlinked) {
-        this.router.navigate(['./participant-detail/' + this.participant.groupParticipantId], { relativeTo: this.route });
+        let routeToNavigateTo: string = `/small-group/${this.groupCardIsDisplayedOn.groupId}/participant-detail/${this.participant.groupParticipantId}`;
+        this.router.navigate([routeToNavigateTo],
+          { relativeTo: this.route });
     }
   }
 

--- a/src/app/components/pin-details/gathering/participant-card/participant-card.component.ts
+++ b/src/app/components/pin-details/gathering/participant-card/participant-card.component.ts
@@ -54,10 +54,13 @@ export class ParticipantCardComponent implements OnInit {
   }
 
   public onParticipantClick(): void {
-      if (this.participant.canBeHyperlinked) {
+    if (this.participant.canBeHyperlinked) {
+      if(this.appSettings.isSmallGroupApp()){
         let routeToNavigateTo: string = `/small-group/${this.groupCardIsDisplayedOn.groupId}/participant-detail/${this.participant.groupParticipantId}`;
-        this.router.navigate([routeToNavigateTo],
-          { relativeTo: this.route });
+        this.router.navigate([routeToNavigateTo]);
+      } else {
+        this.router.navigate(['./participant-detail/' + this.participant.groupParticipantId], { relativeTo: this.route });
+      }
     }
   }
 


### PR DESCRIPTION
Path was relative to parent path. When we came from email link, path was incorrect, so navigation broke.