### PR TITLE
Added data-automation-ids to less accessible error messages

### DIFF
--- a/src/app/components/create-group/page-6/create-group-page-6.component.html
+++ b/src/app/components/create-group/page-6/create-group-page-6.component.html
@@ -14,7 +14,7 @@
         <option *ngFor="let site of sites" [value]="site.dp_RecordID">{{site.dp_RecordName}}</option>
       </select>
 
-      <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || profileForm.controls['crossroadsSite'].valid">
+      <div class="alert alert-danger" role="alert" data-automation-id="siteRequired" [hidden]="(!isSubmitted) || profileForm.controls['crossroadsSite'].valid">
         <crds-content-block id="oneOptionMustBeSelected"></crds-content-block>
       </div>
 
@@ -32,7 +32,7 @@
         </label>
       </div>
 
-      <div class="alert alert-danger" role="alert" [hidden]="(!isSubmitted) || profileForm.controls['gender'].valid">
+      <div class="alert alert-danger" role="alert" data-automation-id="genderRequired" [hidden]="(!isSubmitted) || profileForm.controls['gender'].valid">
         <crds-content-block id="oneOptionMustBeSelected"></crds-content-block>
       </div>
 


### PR DESCRIPTION
Two of the field validation errors for page 6 are not accessible by the usual means we use to validate field errors and needed a more unique way of being located.