### PR TITLE
DE4286 - Pin details layout

### DIFF
--- a/src/app/components/pin-details/gathering/gathering.html
+++ b/src/app/components/pin-details/gathering/gathering.html
@@ -27,12 +27,12 @@
 
       <div class="gathering-description border-top push-half-top">
         <span [innerHTML]="descriptionToDisplay"></span>
-        <br>
         <a *ngIf="!doDisplayFullDesc" (click)="expandGroupDescription()" class="pointer push-right">Read More</a>
-        <input *ngIf = "app.isSmallGroupApp() && isLeader" type="button" class="btn btn-secondary" value="Edit Group" (click)="onEditGroupClicked(pin.gathering.groupId)">
-        <!--<div class="font-size-smaller push-top">-->
-          <!--<a class="pointer" *ngIf="isLeader && !appSettingsService.isConnectApp()" (click)="onEndGroupClicked()">End group</a>-->
-        <!--</div>-->
+      </div>
+
+      <div class="btn-group push-top">
+        <input *ngIf="app.isSmallGroupApp() && isLeader" type="button" class="btn btn-secondary" value="Edit Group" (click)="onEditGroupClicked(pin.gathering.groupId)">
+        <!-- <a *ngIf="isLeader && !appSettingsService.isConnectApp()" class="btn btn-link" (click)="onEndGroupClicked()">End group</a> -->
       </div>
 
       <social-media *ngIf="app.isSmallGroupApp() && showSocial() && isPublicGroup()"> </social-media>

--- a/src/styles/pages/_pin-details.scss
+++ b/src/styles/pages/_pin-details.scss
@@ -53,6 +53,10 @@
   padding-top: 1rem;
   white-space: normal;
   word-wrap: break-word;
+
+  > span > p {
+    display: inline;
+  }
 }
 
 dl {


### PR DESCRIPTION
Rework the pin detail markup so the edit group button is on a new line and the read more link is more inline with the shortened description.

No corresponding PRs. The "end group" button was commented out by Analog. I styled it and recommented it out because YOLO