### PR TITLE
DE4290 - Double scroll

### DIFF
--- a/src/app/components/bland-page/bland-page.component.ts
+++ b/src/app/components/bland-page/bland-page.component.ts
@@ -40,6 +40,9 @@ export class BlandPageComponent implements OnInit, AfterViewInit {
             // This component is rendered within a fauxdal, so we to need the .fauxdal-open
             //  selector to the <body> element when this view is initialized.
             document.querySelector('body').classList.add('fauxdal-open');
+            document.querySelector('body').style.overflowY = 'hidden';
+        } else {
+            document.querySelector('body').style.overflowY = 'auto';
         }
     }
 


### PR DESCRIPTION
Hide the double scrollbar on bland pages.

No corresponding PRs.

Recreate by clicking "Contact Leader" on any group and submitting the form. The confirmation fauxdal is what was effected.