### PR TITLE
DE4487 - Filter icon tray

### DIFF
--- a/src/app/components/search-bar/search-bar.component.html
+++ b/src/app/components/search-bar/search-bar.component.html
@@ -26,8 +26,8 @@
           <div *ngIf="appSettings.isSmallGroupApp()" class="input-separator search-desktop"></div>
 
           <!-- Filter icon button (mobile) -->
-          <span class="filter-btn addon-btn" *ngIf="appSettings.isSmallGroupApp() && !shouldShowSubmit">
-            <button type="button" role="button" (click)="toggleFilters()" [class.open]="state.isFilterDialogOpen" [class.active]="state.isFilterActive">
+          <span class="filter-btn addon-btn" *ngIf="appSettings.isSmallGroupApp()">
+            <button type="button" role="button" (click)="openFilter()" [class.open]="state.isFilterDialogOpen" [class.active]="state.isFilterActive">
               <svg class="icon icon-1" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
                 <use xlink:href="/assets/svgs/icons.svg#equalizer" xmlns:xlink="http://www.w3.org/1999/xlink"></use>
               </svg>
@@ -64,11 +64,11 @@
       </div>
 
       <!-- Mobile searchbar buttons -->
-      <div class="mobile-btn-group" *ngIf="shouldShowSubmit">
+      <div class="mobile-btn-group" *ngIf="appSettings.isSmallGroupApp() && shouldShowSubmit">
         <button type="submit" class="btn btn-secondary" id="searchBtn">
           Search
         </button>
-        <button type="button" class="btn btn-link btn-toggle pull-right hard-sides text-white" [class.active]="state.isFilterDialogOpen" id="addFilters" (click)="openFilter(true)">Add filters</button>
+        <button type="button" class="btn btn-link btn-toggle pull-right hard-sides text-white" [class.active]="state.isFilterDialogOpen" id="addFilters" (click)="openFilter()">Add filters</button>
       </div>
     </form>
   </div>

--- a/src/app/components/search-bar/search-bar.component.spec.ts
+++ b/src/app/components/search-bar/search-bar.component.spec.ts
@@ -140,33 +140,6 @@ describe('SearchBarComponent', () => {
     });
   });
 
-  it('should toggle filters and shouldShowDialog if shouldShowDialog is false', () => {
-    comp.shouldShowSubmit = false;
-    spyOn(comp, 'showLocationBar');
-    mockStateService.getIsFilteredDialogOpen.and.returnValue(false);
-    comp.toggleFilters();
-    expect(mockStateService.setIsFilterDialogOpen).toHaveBeenCalledWith(true);
-    expect(comp.showLocationBar).toHaveBeenCalledWith(true);
-  });
-
-  it('should toggle filters only when shouldshow', () => {
-    comp.shouldShowSubmit = true;
-    spyOn(comp, 'showLocationBar');
-    mockStateService.getIsFilteredDialogOpen.and.returnValue(false);
-    comp.toggleFilters();
-    expect(mockStateService.setIsFilterDialogOpen).toHaveBeenCalledWith(true);
-    expect(comp.showLocationBar).not.toHaveBeenCalled();
-  });
-
-  it('should only toggle filters if onlyToggleFilters is true', () => {
-    mockStateService.getIsFilteredDialogOpen.and.returnValue(true);
-    comp.shouldShowSubmit = true;
-    spyOn(comp, 'showLocationBar');
-    comp.toggleFilters(true);
-    expect(mockStateService.setIsFilterDialogOpen).toHaveBeenCalledWith(false);
-    expect(comp.showLocationBar).not.toHaveBeenCalled();
-  });
-
   it('should toggleLocationBar if in group mode', () => {
     comp.isConnectApp = false;
     comp.shouldShowSubmit = false;

--- a/src/app/components/search-bar/search-bar.component.ts
+++ b/src/app/components/search-bar/search-bar.component.ts
@@ -105,16 +105,9 @@ export class SearchBarComponent implements OnChanges, OnInit {
     document.getElementById('search-bar-input').focus();
   }
 
-  public toggleFilters(onlyToggleFilters: boolean = false): void {
-    const shouldShowDialog = !this.state.getIsFilteredDialogOpen();
-    this.state.setIsFilterDialogOpen(shouldShowDialog);
-    if (onlyToggleFilters === false && shouldShowDialog !== this.shouldShowSubmit) {
-      this.showLocationBar(shouldShowDialog);
-    }
-  }
-
   public openFilter(): void {
     this.state.setIsFilterDialogOpen(true);
+    this.shouldShowSubmit = true;
   }
 
   public showLocationBar(value): void {
@@ -124,7 +117,7 @@ export class SearchBarComponent implements OnChanges, OnInit {
   }
 
   public filterCancel(): void {
-    this.showLocationBar(false);
+    this.shouldShowSubmit = false;
   }
 
   public hideLocationBar(): void {

--- a/src/styles/components/_searchbar.scss
+++ b/src/styles/components/_searchbar.scss
@@ -96,6 +96,10 @@ app-filters {
         @media screen and (min-width: $screen-sm) {
           display: none;
         }
+
+        .open {
+          display: none;
+        }
       }
     }
 
@@ -180,6 +184,13 @@ app-filters {
 
         @media screen and (min-width: $screen-sm) {
           display: block;
+        }
+      }
+
+      // Mobile filter btn
+      .keyword-input {
+        .filter-btn {
+          display: none;
         }
       }
     }


### PR DESCRIPTION
Fix interaction on searchbar/filter tray. 

Filter icon should open filter tray and location input. 
Clicking cancel should close filter tray and location input. 
Clicking into the keyword input should open the location input without opening the filter tray.

Should test /connect and /groups since this component's shared in both.

No corresponding PRs.